### PR TITLE
Feature: Allow grant IDs for grant records

### DIFF
--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/eventstream/GatewayEvent.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/eventstream/GatewayEvent.kt
@@ -27,6 +27,11 @@ class GatewayEvent(sourceEvent: TxEvent) : GatewayEventAdapter(sourceEvent) {
      */
     val targetAccount: String = getEventStringValue(GatewayExpectedAttribute.TARGET_ACCOUNT.key)
 
+    /**
+     * See GatewayExpectedAttribute.ACCESS_GRANT_ID for details.
+     */
+    val accessGrantId: String? = getEventStringValueOrNull(GatewayExpectedAttribute.ACCESS_GRANT_ID.key)
+
     companion object {
         private val logger = KotlinLogging.logger {}
 

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/eventstream/GatewayExpectedAttribute.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/eventstream/GatewayExpectedAttribute.kt
@@ -8,6 +8,12 @@ package tech.figure.objectstore.gateway.eventstream
  */
 enum class GatewayExpectedAttribute(val key: String) {
     /**
+     * An optional free-form text parameter that specifies an additional unique ID for a scope permission record. If
+     * specified, access revocations can directly target this record for removal.
+     */
+    ACCESS_GRANT_ID("object_store_gateway_access_grant_id"),
+
+    /**
      * The type of event to execute upon receipt of this attribute.
      */
     EVENT_TYPE("object_store_gateway_event_type"),

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/model/ScopePermissions.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/model/ScopePermissions.kt
@@ -4,7 +4,9 @@ import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.IntEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.sql.SizedIterable
 import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
 import tech.figure.objectstore.gateway.sql.offsetDatetime
 import java.time.OffsetDateTime
 
@@ -13,6 +15,7 @@ object ScopePermissionsTable : IntIdTable("scope_permissions", "id") {
     val granteeAddress = varchar("grantee_address", 44)
     val granterAddress = varchar("granter_address", 44)
     val created = offsetDatetime("created").clientDefault { OffsetDateTime.now() }
+    val grantId = text("grant_id").nullable()
 
     init {
         uniqueIndex(scopeAddress, granteeAddress, granterAddress)
@@ -20,28 +23,68 @@ object ScopePermissionsTable : IntIdTable("scope_permissions", "id") {
 }
 
 open class ScopePermissionClass : IntEntityClass<ScopePermission>(ScopePermissionsTable) {
-    fun new(scopeAddress: String, granteeAddress: String, granterAddress: String) = findByScopeIdAndAddresses(scopeAddress, granteeAddress, granterAddress) ?: new() {
+    fun new(
+        scopeAddress: String,
+        granteeAddress: String,
+        granterAddress: String,
+        grantId: String? = null,
+    ): ScopePermission = findByScopeIdAndAddresses(
+        scopeAddress = scopeAddress,
+        granteeAddress = granteeAddress,
+        granterAddress = granterAddress,
+        grantId = grantId,
+    ) ?: new {
         this.scopeAddress = scopeAddress
         this.granteeAddress = granteeAddress
         this.granterAddress = granterAddress
+        this.grantId = grantId
     }
 
-    private fun findByScopeIdAndAddresses(scopeAddress: String, granteeAddress: String, granterAddress: String) = find {
-        ScopePermissionsTable.scopeAddress eq scopeAddress and
-            (ScopePermissionsTable.granteeAddress eq granteeAddress) and
-            (ScopePermissionsTable.granterAddress eq granterAddress)
+    private fun findByScopeIdAndAddresses(
+        scopeAddress: String,
+        granteeAddress: String,
+        granterAddress: String,
+        grantId: String?,
+    ) = find {
+        ScopePermissionsTable.scopeAddress.eq(scopeAddress)
+            .and { ScopePermissionsTable.granteeAddress eq granteeAddress }
+            .and { ScopePermissionsTable.granterAddress eq granterAddress }
+            .let { query ->
+                if (grantId != null) {
+                    query.and { ScopePermissionsTable.grantId.eq(grantId) }
+                } else {
+                    query
+                }
+            }
     }.firstOrNull()
 
-    fun findAllByScopeIdAndGranteeAddress(scopeAddress: String, granteeAddress: String) = find {
+    fun findAllByScopeIdAndGranteeAddress(scopeAddress: String, granteeAddress: String): SizedIterable<ScopePermission> = find {
         ScopePermissionsTable.scopeAddress eq scopeAddress and (ScopePermissionsTable.granteeAddress eq granteeAddress)
+    }
+
+    fun revokeAccessPermission(
+        scopeAddress: String,
+        granteeAddress: String,
+        grantId: String? = null,
+    ): Int = ScopePermissionsTable.deleteWhere {
+        ScopePermissionsTable.scopeAddress.eq(scopeAddress)
+            .and { ScopePermissionsTable.granteeAddress eq granteeAddress }
+            .let { query ->
+                if (grantId != null) {
+                    query.and { ScopePermissionsTable.grantId eq grantId }
+                } else {
+                    query
+                }
+            }
     }
 }
 
 class ScopePermission(id: EntityID<Int>) : IntEntity(id) {
     companion object : ScopePermissionClass()
 
-    var scopeAddress by ScopePermissionsTable.scopeAddress
-    var granteeAddress by ScopePermissionsTable.granteeAddress
-    var granterAddress by ScopePermissionsTable.granterAddress
-    val created by ScopePermissionsTable.created
+    var scopeAddress: String by ScopePermissionsTable.scopeAddress
+    var granteeAddress: String by ScopePermissionsTable.granteeAddress
+    var granterAddress: String by ScopePermissionsTable.granterAddress
+    val created: OffsetDateTime by ScopePermissionsTable.created
+    var grantId: String? by ScopePermissionsTable.grantId
 }

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/model/ScopePermissions.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/model/ScopePermissions.kt
@@ -18,7 +18,7 @@ object ScopePermissionsTable : IntIdTable("scope_permissions", "id") {
     val grantId = text("grant_id").nullable()
 
     init {
-        uniqueIndex(scopeAddress, granteeAddress, granterAddress)
+        uniqueIndex(scopeAddress, granteeAddress, granterAddress, grantId)
     }
 }
 
@@ -49,13 +49,7 @@ open class ScopePermissionClass : IntEntityClass<ScopePermission>(ScopePermissio
         ScopePermissionsTable.scopeAddress.eq(scopeAddress)
             .and { ScopePermissionsTable.granteeAddress eq granteeAddress }
             .and { ScopePermissionsTable.granterAddress eq granterAddress }
-            .let { query ->
-                if (grantId != null) {
-                    query.and { ScopePermissionsTable.grantId.eq(grantId) }
-                } else {
-                    query
-                }
-            }
+            .and { ScopePermissionsTable.grantId eq grantId }
     }.firstOrNull()
 
     fun findAllByScopeIdAndGranteeAddress(scopeAddress: String, granteeAddress: String): SizedIterable<ScopePermission> = find {

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/repository/ScopePermissionsRepository.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/repository/ScopePermissionsRepository.kt
@@ -1,17 +1,18 @@
 package tech.figure.objectstore.gateway.repository
 
-import org.jetbrains.exposed.sql.and
-import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.springframework.stereotype.Service
 import tech.figure.objectstore.gateway.model.ScopePermission
-import tech.figure.objectstore.gateway.model.ScopePermissionsTable
-import tech.figure.objectstore.gateway.model.ScopePermissionsTable.granterAddress
 
 @Service
 class ScopePermissionsRepository {
-    fun addAccessPermission(scopeAddress: String, granteeAddress: String, granterAddress: String) {
-        transaction { ScopePermission.new(scopeAddress, granteeAddress, granterAddress) }
+    fun addAccessPermission(
+        scopeAddress: String,
+        granteeAddress: String,
+        granterAddress: String,
+        grantId: String? = null,
+    ) {
+        transaction { ScopePermission.new(scopeAddress, granteeAddress, granterAddress, grantId) }
     }
 
     fun getAccessGranterAddresses(scopeAddress: String, granteeAddress: String): List<String> = transaction {
@@ -25,11 +26,14 @@ class ScopePermissionsRepository {
      * @param scopeAddress The bech32 address of the scope for which to revoke access.
      * @param granteeAddress The address that has been granted access to the scope.  All records that link this address
      * to the target scope will be removed.
+     * @param grantId An optional parameter that denotes that only records with this specific grant ID should be deleted.
+     * If omitted, all records with this scopeAddress and granteeAddress combination will be deleted.
      */
-    fun revokeAccessPermission(scopeAddress: String, granteeAddress: String): Int = transaction {
-        ScopePermissionsTable.deleteWhere {
-            ScopePermissionsTable.scopeAddress.eq(scopeAddress)
-                .and { ScopePermissionsTable.granteeAddress.eq(granteeAddress) }
-        }
+    fun revokeAccessPermission(scopeAddress: String, granteeAddress: String, grantId: String? = null): Int = transaction {
+        ScopePermission.revokeAccessPermission(
+            scopeAddress = scopeAddress,
+            granteeAddress = granteeAddress,
+            grantId = grantId,
+        )
     }
 }

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/service/StreamEventHandlerService.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/service/StreamEventHandlerService.kt
@@ -77,6 +77,7 @@ class StreamEventHandlerService(
             scopeAddress = gatewayEvent.scopeAddress,
             granterAddress = granterAddress,
             granteeAddress = gatewayEvent.targetAccount,
+            grantId = gatewayEvent.accessGrantId,
         )
     }
 
@@ -223,12 +224,15 @@ class StreamEventHandlerService(
      * @param granteeAddress The bech32 address of the target account for which to permit scope record access.
      * @param granterAddress The bech32 address of the key that will be used to deserialize object store scope record data
      * upon requests made by the grantee.
+     * @param grantId An optional parameter that denotes that only records with this specific grant ID should be deleted.
+     * If omitted, all records with this scopeAddress and granteeAddress combination will be deleted.
      */
     private fun handleAccessGrant(
         txHash: String,
         scopeAddress: String,
         granteeAddress: String,
         granterAddress: String,
+        grantId: String? = null,
     ) {
         // fetch scope and add all hashes to lookup? Or just add scope to lookup? (probably do all hashes in v2)
         logger.info("[ACCESS GRANT | Tx: $txHash]: Adding account [$granteeAddress] to access list for scope [$scopeAddress] with granter [$granterAddress]")
@@ -236,6 +240,7 @@ class StreamEventHandlerService(
             scopeAddress = scopeAddress,
             granteeAddress = granteeAddress,
             granterAddress = granterAddress,
+            grantId = grantId,
         )
     }
 }

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/service/StreamEventHandlerService.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/service/StreamEventHandlerService.kt
@@ -103,10 +103,11 @@ class StreamEventHandlerService(
                 return
             }
         }
-        logger.info("[ACCESS REVOKE | Tx: ${gatewayEvent.txHash}]: Revoking account [${gatewayEvent.targetAccount}] from access list for scope [${gatewayEvent.scopeAddress}]")
+        logger.info("[ACCESS REVOKE | Tx: ${gatewayEvent.txHash}]: Revoking account [${gatewayEvent.targetAccount}] from access list for scope [${gatewayEvent.scopeAddress}]${if (gatewayEvent.accessGrantId != null) " with grant ID [${gatewayEvent.accessGrantId}]" else ""}")
         scopePermissionsRepository.revokeAccessPermission(
             scopeAddress = gatewayEvent.scopeAddress,
             granteeAddress = gatewayEvent.targetAccount,
+            grantId = gatewayEvent.accessGrantId,
         )
     }
 

--- a/server/src/main/resources/db/migration/V3_0__Scope_Permissions_Grant_ID.sql
+++ b/server/src/main/resources/db/migration/V3_0__Scope_Permissions_Grant_ID.sql
@@ -1,3 +1,10 @@
 ALTER TABLE scope_permissions ADD COLUMN grant_id text;
 
 CREATE INDEX IF NOT EXISTS scope_permissions_grant_id_idx ON scope_permissions(grant_id);
+
+-- Remove old index that enforces unique on scope_address/grantee_address/granter_address
+DROP INDEX IF EXISTS scope_permissions_scope_address_grantee_address_granter_address;
+
+-- LMAO BEST NAME EVER.  Ensures that there can be duplicate grants from granters to grantees on a scope address, as
+-- long as the duplicate specifies a null or newly-unique grant id
+CREATE UNIQUE INDEX IF NOT EXISTS scope_permissions_scope_addr_grantee_addr_granter_addr_grant_id ON scope_permissions (scope_address, grantee_address, granter_address, grant_id);

--- a/server/src/main/resources/db/migration/V3_0__Scope_Permissions_Grant_ID.sql
+++ b/server/src/main/resources/db/migration/V3_0__Scope_Permissions_Grant_ID.sql
@@ -1,0 +1,3 @@
+ALTER TABLE scope_permissions ADD COLUMN grant_id text;
+
+CREATE INDEX IF NOT EXISTS scope_permissions_grant_id_idx ON scope_permissions(grant_id);

--- a/server/src/main/resources/db/migration/V3_0__Scope_Permissions_Grant_ID.sql
+++ b/server/src/main/resources/db/migration/V3_0__Scope_Permissions_Grant_ID.sql
@@ -5,6 +5,16 @@ CREATE INDEX IF NOT EXISTS scope_permissions_grant_id_idx ON scope_permissions(g
 -- Remove old index that enforces unique on scope_address/grantee_address/granter_address
 DROP INDEX IF EXISTS scope_permissions_scope_address_grantee_address_granter_address;
 
--- LMAO BEST NAME EVER.  Ensures that there can be duplicate grants from granters to grantees on a scope address, as
--- long as the duplicate specifies a null or newly-unique grant id
-CREATE UNIQUE INDEX IF NOT EXISTS scope_permissions_scope_addr_grantee_addr_granter_addr_grant_id ON scope_permissions (scope_address, grantee_address, granter_address, grant_id);
+-- Ensures that there can be duplicate grants from granters to grantees on a scope address, as long as the duplicate
+-- specifies a newly-unique grant id
+CREATE UNIQUE INDEX IF NOT EXISTS scope_permissions_scope_adr_grantee_adr_granter_adr_grant_id_nn
+    ON scope_permissions (scope_address, grantee_address, granter_address, grant_id)
+    WHERE grant_id IS NOT NULL;
+
+-- Companion index to the above index.  Nulls in indices are not handled in the way one might think, where they indicate
+-- another unique value.  Instead, they are disregarded and any number of records that include null as a value are
+-- allowed.  To circumvent this, two unique indices can be created that handle the null and non-null case of a single
+-- column.  Fortunately, only grant_id is nullable, which makes this combo relatively simplistic to declare.
+CREATE UNIQUE INDEX IF NOT EXISTS scope_permissions_scope_adr_grantee_adr_granter_adr_grant_id_nl
+    ON scope_permissions (scope_address, grantee_address, granter_address)
+    WHERE grant_id IS NULL;

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/repository/ScopePermissionsRepositoryTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/repository/ScopePermissionsRepositoryTest.kt
@@ -34,6 +34,22 @@ class ScopePermissionsRepositoryTest {
                 assertEquals(records.first().scopeAddress, scopeAddress, "The scope permission record should have the proper scope address")
                 assertEquals(records.first().granterAddress, granterAddress, "The scope permission record should have the proper granter")
                 assertEquals(records.first().granteeAddress, granteeAddress, "The scope permission record should have the proper grantee")
+                assertEquals(records.first().grantId, null, "The scope permission record should have a null grant id by default")
+            }
+        }
+    }
+
+    @Test
+    fun `addAccessPermission should not insert duplicate records when a null grantId is supplied`() {
+        repository.addAccessPermission(scopeAddress, granteeAddress, granterAddress)
+        repository.addAccessPermission(scopeAddress, granteeAddress, granterAddress)
+        transaction {
+            ScopePermission.findAllByScopeIdAndGranteeAddress(scopeAddress, granteeAddress).also { records ->
+                assertEquals(
+                    expected = 1,
+                    actual = records.count(),
+                    message = "Duplicate records with null grant ids should be ignored and only one copy of the record should be inserted",
+                )
             }
         }
     }

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/service/StreamEventHandlerServiceTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/service/StreamEventHandlerServiceTest.kt
@@ -322,24 +322,35 @@ class StreamEventHandlerServiceTest {
 
         submitGatewayEvent(GatewayExpectedEventType.ACCESS_GRANT, grantId = firstGrantId)
         submitGatewayEvent(GatewayExpectedEventType.ACCESS_GRANT, grantId = secondGrantId)
+        submitGatewayEvent(GatewayExpectedEventType.ACCESS_GRANT)
 
         assertScopePermissionExists(grantId = firstGrantId)
         assertScopePermissionExists(grantId = secondGrantId)
+        assertScopePermissionExists(grantId = null)
 
         submitGatewayEvent(GatewayExpectedEventType.ACCESS_REVOKE, grantId = "other grant id")
 
         assertScopePermissionExists(grantId = firstGrantId, messagePrefix = "First grant should still exist after targeting a nonexistent grant id")
         assertScopePermissionExists(grantId = secondGrantId, messagePrefix = "Second grant should still exist after targeting a nonexistent grant id")
+        assertScopePermissionExists(grantId = null, messagePrefix = "Null id grant should still exist after targeting a nonexistent grant id")
 
         submitGatewayEvent(GatewayExpectedEventType.ACCESS_REVOKE, grantId = firstGrantId)
 
         assertScopePermissionDoesNotExist(grantId = firstGrantId, messagePrefix = "First grant should be deleted after an access revoke requested it")
         assertScopePermissionExists(grantId = secondGrantId, messagePrefix = "Second grant should still exist after only deleting the first grant id's record")
+        assertScopePermissionExists(grantId = null, messagePrefix = "Null id grant should still exist after only deleting the first grant id's record")
 
         submitGatewayEvent(GatewayExpectedEventType.ACCESS_REVOKE, grantId = secondGrantId)
 
         assertScopePermissionDoesNotExist(grantId = firstGrantId, messagePrefix = "First grant should remain deleted after deleting the second grant")
         assertScopePermissionDoesNotExist(grantId = secondGrantId, messagePrefix = "Second grant should be deleted after an access revoke requested it")
+        assertScopePermissionExists(grantId = null, messagePrefix = "Null id grant should still exist after only deleting the second grant id's record")
+
+        submitGatewayEvent(GatewayExpectedEventType.ACCESS_REVOKE)
+
+        assertScopePermissionDoesNotExist(grantId = firstGrantId, messagePrefix = "First grant should remain deleted after removing grants with a null grant id")
+        assertScopePermissionDoesNotExist(grantId = secondGrantId, messagePrefix = "Second grant should remain deleted after removing grants with a null grant id")
+        assertScopePermissionDoesNotExist(grantId = null, messagePrefix = "Null id grant should be deleted after an access revoke requested all grants to be deleted")
 
         assertEquals(
             expected = emptyList(),

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/service/StreamEventHandlerServiceTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/service/StreamEventHandlerServiceTest.kt
@@ -18,6 +18,7 @@ import io.provenance.metadata.v1.PartyType
 import io.provenance.metadata.v1.ScopeResponse
 import io.provenance.metadata.v1.SessionWrapper
 import io.provenance.scope.encryption.ecies.ECUtils
+import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.deleteAll
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.jupiter.api.BeforeEach
@@ -27,7 +28,6 @@ import tech.figure.objectstore.gateway.configuration.ProvenanceProperties
 import tech.figure.objectstore.gateway.eventstream.AcContractKey
 import tech.figure.objectstore.gateway.eventstream.GatewayExpectedAttribute
 import tech.figure.objectstore.gateway.eventstream.GatewayExpectedEventType
-import tech.figure.objectstore.gateway.extensions.checkNotNull
 import tech.figure.objectstore.gateway.model.ScopePermission
 import tech.figure.objectstore.gateway.model.ScopePermissionsTable
 import tech.figure.objectstore.gateway.repository.ScopePermissionsRepository
@@ -35,6 +35,8 @@ import tech.figure.objectstore.gateway.util.toByteString
 import java.time.OffsetDateTime
 import java.util.Base64
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 @SpringBootTest
 class StreamEventHandlerServiceTest {
@@ -259,22 +261,90 @@ class StreamEventHandlerServiceTest {
     }
 
     @Test
-    fun `StreamEventHandlerService removes all and disregards grant id when revoke requests that`() {
+    fun `StreamEventHandlerService allows multiple duplicate grants with different grant ids`() {
         setUp()
 
-        val grantId = "the best grant ever"
+        val firstGrantId = "first-grant-id"
+        val secondGrantId = "second-grant-id"
 
-        submitGatewayEvent(GatewayExpectedEventType.ACCESS_GRANT, grantId = grantId)
+        submitGatewayEvent(GatewayExpectedEventType.ACCESS_GRANT, firstGrantId)
+        submitGatewayEvent(GatewayExpectedEventType.ACCESS_GRANT, secondGrantId)
+        submitGatewayEvent(GatewayExpectedEventType.ACCESS_GRANT)
 
-        val scopePermission = transaction {
-            ScopePermission.find { ScopePermissionsTable.grantId eq grantId }
-                .singleOrNull()
-                .checkNotNull { "A single record should be inserted with the given grant id after specifying the grant id" }
-        }
         assertEquals(
-            expected = onboardingOwnerAddress,
-            actual = scopePermission.granterAddress,
-            message = "The correct granter should be selected",
+            expected = listOf(onboardingOwnerAddress),
+            actual = scopePermissionsRepository.getAccessGranterAddresses(scopeAddress, grantee.bech32Address).distinct(),
+            message = "All granters should be located for the given combinations, but because they all use the same granter, only one result should be returned",
+        )
+        assertScopePermissionExists(grantId = firstGrantId)
+        assertScopePermissionExists(grantId = secondGrantId)
+        assertScopePermissionExists(grantId = null)
+    }
+
+    @Test
+    fun `StreamEventHandlerService removes any and disregards grant id when revoke expression does not include it`() {
+        setUp()
+
+        val firstGrantId = "the best grant ever"
+        val secondGrantId = "the betterest grant ever"
+        val thirdGrantId = "I don't even have a fake adjective for this one"
+
+        submitGatewayEvent(GatewayExpectedEventType.ACCESS_GRANT, grantId = firstGrantId)
+        submitGatewayEvent(GatewayExpectedEventType.ACCESS_GRANT, grantId = secondGrantId)
+        submitGatewayEvent(GatewayExpectedEventType.ACCESS_GRANT, grantId = thirdGrantId)
+        submitGatewayEvent(GatewayExpectedEventType.ACCESS_GRANT, grantId = null)
+
+        assertScopePermissionExists(grantId = firstGrantId)
+        assertScopePermissionExists(grantId = secondGrantId)
+        assertScopePermissionExists(grantId = thirdGrantId)
+        assertScopePermissionExists(grantId = null)
+
+        submitGatewayEvent(GatewayExpectedEventType.ACCESS_REVOKE)
+
+        assertScopePermissionDoesNotExist(grantId = firstGrantId, messagePrefix = "The first grant should be removed after an access revoke does not supply a grant id")
+        assertScopePermissionDoesNotExist(grantId = secondGrantId, messagePrefix = "The second grant should be removed after an access revoke does not supply a grant id")
+        assertScopePermissionDoesNotExist(grantId = thirdGrantId, messagePrefix = "The third grant should be removed after an access revoke does not supply a grant id")
+        assertScopePermissionDoesNotExist(grantId = null, messagePrefix = "The null id grant should be removed after an access revoke does not supply a grant id")
+
+        assertEquals(
+            expected = emptyList(),
+            actual = scopePermissionsRepository.getAccessGranterAddresses(scopeAddress, grantee.bech32Address),
+            message = "All grants should be removed when the revocation does not supply a targeted grant id",
+        )
+    }
+
+    @Test
+    fun `StreamEventHandlerService removes grant id specifically upon request`() {
+        setUp()
+
+        val firstGrantId = "first-grant"
+        val secondGrantId = "second-grant"
+
+        submitGatewayEvent(GatewayExpectedEventType.ACCESS_GRANT, grantId = firstGrantId)
+        submitGatewayEvent(GatewayExpectedEventType.ACCESS_GRANT, grantId = secondGrantId)
+
+        assertScopePermissionExists(grantId = firstGrantId)
+        assertScopePermissionExists(grantId = secondGrantId)
+
+        submitGatewayEvent(GatewayExpectedEventType.ACCESS_REVOKE, grantId = "other grant id")
+
+        assertScopePermissionExists(grantId = firstGrantId, messagePrefix = "First grant should still exist after targeting a nonexistent grant id")
+        assertScopePermissionExists(grantId = secondGrantId, messagePrefix = "Second grant should still exist after targeting a nonexistent grant id")
+
+        submitGatewayEvent(GatewayExpectedEventType.ACCESS_REVOKE, grantId = firstGrantId)
+
+        assertScopePermissionDoesNotExist(grantId = firstGrantId, messagePrefix = "First grant should be deleted after an access revoke requested it")
+        assertScopePermissionExists(grantId = secondGrantId, messagePrefix = "Second grant should still exist after only deleting the first grant id's record")
+
+        submitGatewayEvent(GatewayExpectedEventType.ACCESS_REVOKE, grantId = secondGrantId)
+
+        assertScopePermissionDoesNotExist(grantId = firstGrantId, messagePrefix = "First grant should remain deleted after deleting the second grant")
+        assertScopePermissionDoesNotExist(grantId = secondGrantId, messagePrefix = "Second grant should be deleted after an access revoke requested it")
+
+        assertEquals(
+            expected = emptyList(),
+            actual = scopePermissionsRepository.getAccessGranterAddresses(scopeAddress, grantee.bech32Address),
+            message = "After all grants have been deleted, no granter addresses should be available to the grantee",
         )
     }
 
@@ -323,6 +393,57 @@ class StreamEventHandlerServiceTest {
                 note = note,
             )
         )
+    }
+
+    private fun assertScopePermissionExists(
+        targetScopeAddress: String = scopeAddress,
+        granterAddress: String = onboardingOwnerAddress,
+        granteeAddress: String = grantee.bech32Address,
+        grantId: String? = null,
+        messagePrefix: String? = null,
+    ): ScopePermission = findScopePermissionOrNull(
+        scopeAddress = targetScopeAddress,
+        granterAddress = granterAddress,
+        granteeAddress = granteeAddress,
+        grantId = grantId,
+    ).let { scopePermissionOrNull ->
+        assertNotNull(
+            actual = scopePermissionOrNull,
+            message = "${messagePrefix ?: "Scope permission does not exist"}: Expected scope permission with scope address [$targetScopeAddress], granter [$granterAddress], grantee [$granteeAddress], and grant ID [$grantId] to exist",
+        )
+        scopePermissionOrNull
+    }
+
+    private fun assertScopePermissionDoesNotExist(
+        targetScopeAddress: String = scopeAddress,
+        granterAddress: String = onboardingOwnerAddress,
+        granteeAddress: String = grantee.bech32Address,
+        grantId: String? = null,
+        messagePrefix: String? = null,
+    ) {
+        assertNull(
+            actual = findScopePermissionOrNull(
+                scopeAddress = targetScopeAddress,
+                granterAddress = granterAddress,
+                granteeAddress = granteeAddress,
+                grantId = grantId,
+            ),
+            message = "${messagePrefix ?: "Scope permission should not exist"}: Found scope permission with scope address [$targetScopeAddress], granter [$granterAddress], grantee [$granteeAddress], and grant ID [$grantId]",
+        )
+    }
+
+    private fun findScopePermissionOrNull(
+        scopeAddress: String,
+        granterAddress: String,
+        granteeAddress: String,
+        grantId: String?,
+    ): ScopePermission? = transaction {
+        ScopePermission.find {
+            ScopePermissionsTable.scopeAddress.eq(scopeAddress)
+                .and { ScopePermissionsTable.granterAddress eq granterAddress }
+                .and { ScopePermissionsTable.granteeAddress eq granteeAddress }
+                .and { ScopePermissionsTable.grantId eq grantId }
+        }.singleOrNull()
     }
 
     private fun String.base64Encode(): String = Base64.getEncoder().encodeToString(toByteArray())


### PR DESCRIPTION
# Description
This includes a `grant_id` column in the `scope_permissions` table, which allows events to specify a unique identity alongside the original values to specifically label an access grant.  This will allow the asset classification smart contract to enable and disable verifier access dynamically based upon intercepted requests.

## Changes
- Add `accessGrantId` to the `GatewayEvent`, which expects an `object_store_gateway_access_grant_id` value to be sent via smart contract.
- Add an `grant_id` column to the `scope_permissions` table, adjusting the existing unique index to allow the new structure to be used.