### PR TITLE
Feature: Manual scope grants / revokes

### DIFF
--- a/proto/src/main/proto/tech/figure/objectstore/gateway/gateway.proto
+++ b/proto/src/main/proto/tech/figure/objectstore/gateway/gateway.proto
@@ -7,6 +7,9 @@ service Gateway {
   rpc PutObject (PutObjectRequest) returns (PutObjectResponse) {};
   rpc FetchObjectByHash (FetchObjectByHashRequest) returns (FetchObjectByHashResponse) {};
 
+  rpc GrantScopePermission (GrantScopePermissionRequest) returns (GrantScopePermissionResponse) {};
+  rpc RevokeScopePermission (RevokeScopePermissionRequest) returns (RevokeScopePermissionResponse) {};
+
   // todo: admin only service method to add an address to the acl for a granter
   // todo: admin only service method to remove an address from the acl for a granter
 }
@@ -36,6 +39,28 @@ message FetchObjectByHashRequest {
 
 message FetchObjectByHashResponse {
   ObjectWithMeta object = 1;
+}
+
+message GrantScopePermissionRequest {
+  string scope_address = 1; // A bech32 scope address. The account referenced by grantee_address will receive read permissions through this service to the scope's underlying records
+  string grantee_address = 2; // A bech32 account address for which to grant read access to the scope's records
+  string grant_id = 3; // An optional parameter that specifies a unique identifier by which to label the grant entry that will be created
+}
+
+message GrantScopePermissionResponse {
+  GrantScopePermissionRequest request = 1; // The request that evoked this response
+  string granter_address = 2; // The address that has read access to the requested scope's underlying records
+}
+
+message RevokeScopePermissionRequest {
+  string scope_address = 1; // A bech32 scope address.  All grants for this scope to the target grantee_address will be removed
+  string grantee_address = 2; // A bech32 account address.  All grants that this account has received for the scope will be removed
+  string grant_id = 3; // An optional parameter that specifies a unique identifier by which to target existing grant entries.  If this value is omitted, all grants (including those labeled with grant ids) will be removed for this scope/account combo
+}
+
+message RevokeScopePermissionResponse {
+  RevokeScopePermissionRequest request = 1; // The request that evoked this response
+  int32 revoked_grants_count = 2; // The amount of grants that the request successfully revoked
 }
 
 message ObjectWithMeta {

--- a/proto/src/main/proto/tech/figure/objectstore/gateway/gateway.proto
+++ b/proto/src/main/proto/tech/figure/objectstore/gateway/gateway.proto
@@ -6,12 +6,8 @@ service Gateway {
   rpc FetchObject (FetchObjectRequest) returns (FetchObjectResponse) {};
   rpc PutObject (PutObjectRequest) returns (PutObjectResponse) {};
   rpc FetchObjectByHash (FetchObjectByHashRequest) returns (FetchObjectByHashResponse) {};
-
   rpc GrantScopePermission (GrantScopePermissionRequest) returns (GrantScopePermissionResponse) {};
   rpc RevokeScopePermission (RevokeScopePermissionRequest) returns (RevokeScopePermissionResponse) {};
-
-  // todo: admin only service method to add an address to the acl for a granter
-  // todo: admin only service method to remove an address from the acl for a granter
 }
 
 message FetchObjectRequest {
@@ -50,6 +46,7 @@ message GrantScopePermissionRequest {
 message GrantScopePermissionResponse {
   GrantScopePermissionRequest request = 1; // The request that evoked this response
   string granter_address = 2; // The address that has read access to the requested scope's underlying records
+  bool grant_accepted = 3; // If true, the grant was successfully added from the request
 }
 
 message RevokeScopePermissionRequest {
@@ -61,6 +58,7 @@ message RevokeScopePermissionRequest {
 message RevokeScopePermissionResponse {
   RevokeScopePermissionRequest request = 1; // The request that evoked this response
   int32 revoked_grants_count = 2; // The amount of grants that the request successfully revoked
+  bool revoke_accepted = 3; // If true, the revoke was successfully processed.  This indicates that the sender had the rights to make the request, even if zero grants were revoked based on the input
 }
 
 message ObjectWithMeta {

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServer.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServer.kt
@@ -87,9 +87,9 @@ class ObjectStoreGatewayServer(
         val grantResponse = scopePermissionsService.processAccessGrant(
             scopeAddress = request.scopeAddress,
             granteeAddress = request.granteeAddress,
-            grantSourceAddresses = listOf(requesterAddress),
+            grantSourceAddresses = setOf(requesterAddress),
             // The application's admin should be able to manually grant any permission that is desired
-            additionalAuthorizedAddresses = listOf(masterKey.publicKey.getAddress(mainNet = provenanceProperties.mainNet)),
+            additionalAuthorizedAddresses = setOf(masterKey.publicKey.getAddress(mainNet = provenanceProperties.mainNet)),
             grantId = grantId,
             sourceDetails = sourceDetails,
         )
@@ -126,8 +126,8 @@ class ObjectStoreGatewayServer(
         val revokeResponse = scopePermissionsService.processAccessRevoke(
             scopeAddress = request.scopeAddress,
             granteeAddress = request.granteeAddress,
-            revokeSourceAddresses = listOf(requesterAddress),
-            additionalAuthorizedAddresses = listOf(
+            revokeSourceAddresses = setOf(requesterAddress),
+            additionalAuthorizedAddresses = setOf(
                 // The grantee should be able to remove their own grants upon request
                 request.granteeAddress,
                 // The application's admin should be able to manually revoke any permission that is desired

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServer.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServer.kt
@@ -1,20 +1,32 @@
 package tech.figure.objectstore.gateway.server
 
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
 import io.grpc.stub.StreamObserver
+import io.provenance.scope.encryption.model.KeyRef
+import io.provenance.scope.encryption.util.getAddress
 import mu.KLogging
 import org.lognet.springboot.grpc.GRpcService
 import tech.figure.objectstore.gateway.GatewayGrpc
 import tech.figure.objectstore.gateway.GatewayOuterClass
+import tech.figure.objectstore.gateway.GatewayOuterClass.GrantScopePermissionResponse
 import tech.figure.objectstore.gateway.address
+import tech.figure.objectstore.gateway.configuration.ProvenanceProperties
 import tech.figure.objectstore.gateway.publicKey
 import tech.figure.objectstore.gateway.server.interceptor.JwtServerInterceptor
+import tech.figure.objectstore.gateway.service.GrantResponse
 import tech.figure.objectstore.gateway.service.ObjectService
+import tech.figure.objectstore.gateway.service.RevokeResponse
 import tech.figure.objectstore.gateway.service.ScopeFetchService
+import tech.figure.objectstore.gateway.service.ScopePermissionsService
 
 @GRpcService(interceptors = [JwtServerInterceptor::class])
 class ObjectStoreGatewayServer(
+    private val masterKey: KeyRef,
     private val scopeFetchService: ScopeFetchService,
+    private val scopePermissionsService: ScopePermissionsService,
     private val objectService: ObjectService,
+    private val provenanceProperties: ProvenanceProperties,
 ) : GatewayGrpc.GatewayImplBase() {
 
     companion object : KLogging()
@@ -36,8 +48,76 @@ class ObjectStoreGatewayServer(
 
     override fun grantScopePermission(
         request: GatewayOuterClass.GrantScopePermissionRequest,
-        responseObserver: StreamObserver<GatewayOuterClass.GrantScopePermissionResponse>,
+        responseObserver: StreamObserver<GrantScopePermissionResponse>,
     ) {
+        val requesterAddress = publicKey().getAddress(mainNet = provenanceProperties.mainNet)
+        val grantId = request.grantId.takeIf { it.isNotBlank() }
+        val sourceDetails = "Manual grant request by $requesterAddress for scope ${request.scopeAddress}, grantee ${request.granteeAddress}${if (grantId != null) ", grantId $grantId" else ""}"
+        val grantResponse = scopePermissionsService.processAccessGrant(
+            scopeAddress = request.scopeAddress,
+            granteeAddress = request.granteeAddress,
+            grantSourceAddresses = listOf(requesterAddress),
+            // The application's admin should be able to manually grant any permission that is desired
+            additionalAuthorizedAddresses = listOf(masterKey.publicKey.getAddress(mainNet = provenanceProperties.mainNet)),
+            grantId = grantId,
+            sourceDetails = sourceDetails,
+        )
+        if (grantResponse is GrantResponse.Error) {
+            logger.error("ERROR $sourceDetails", grantResponse.cause)
+            responseObserver.onError(StatusRuntimeException(Status.UNKNOWN.withCause(grantResponse.cause)))
+            return
+        }
+        responseObserver.onNext(
+            GrantScopePermissionResponse.newBuilder().also { rpcResponse ->
+                rpcResponse.request = request
+                if (grantResponse is GrantResponse.Accepted) {
+                    rpcResponse.grantAccepted = true
+                    rpcResponse.granterAddress = grantResponse.granterAddress
+                } else if (grantResponse is GrantResponse.Rejected) {
+                    rpcResponse.grantAccepted = false
+                    logger.warn("REJECTED $sourceDetails: ${grantResponse.message}")
+                }
+            }.build()
+        )
+        responseObserver.onCompleted()
+    }
+
+    override fun revokeScopePermission(
+        request: GatewayOuterClass.RevokeScopePermissionRequest,
+        responseObserver: StreamObserver<GatewayOuterClass.RevokeScopePermissionResponse>,
+    ) {
+        val requesterAddress = publicKey().getAddress(mainNet = provenanceProperties.mainNet)
+        val grantId = request.grantId.takeIf { it.isNotBlank() }
+        val sourceDetails = "Main revoke request by $requesterAddress for scope ${request.scopeAddress}, grantee ${request.granteeAddress}${if (grantId != null) ", grantId $grantId" else ""}"
+        val revokeResponse = scopePermissionsService.processAccessRevoke(
+            scopeAddress = request.scopeAddress,
+            granteeAddress = request.granteeAddress,
+            revokeSourceAddresses = listOf(requesterAddress),
+            additionalAuthorizedAddresses = listOf(
+                // The grantee should be able to remove their own grants upon request
+                request.granteeAddress,
+                masterKey.publicKey.getAddress(mainNet = provenanceProperties.mainNet),
+            ),
+            grantId = grantId,
+            sourceDetails = sourceDetails,
+        )
+        if (revokeResponse is RevokeResponse.Error) {
+            logger.error("ERROR $sourceDetails", revokeResponse.cause)
+            responseObserver.onError(StatusRuntimeException(Status.UNKNOWN.withCause(revokeResponse.cause)))
+        }
+        responseObserver.onNext(
+            GatewayOuterClass.RevokeScopePermissionResponse.newBuilder().also { rpcResponse ->
+                rpcResponse.request = request
+                if (revokeResponse is RevokeResponse.Accepted) {
+                    rpcResponse.revokeAccepted = true
+                    rpcResponse.revokedGrantsCount = revokeResponse.revokedGrantsCount
+                } else if (revokeResponse is RevokeResponse.Rejected) {
+                    rpcResponse.revokeAccepted = false
+                    logger.warn("REJECTED $sourceDetails: ${revokeResponse.message}")
+                }
+            }.build()
+        )
+        responseObserver.onCompleted()
     }
 
     override fun putObject(

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServer.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServer.kt
@@ -23,7 +23,7 @@ class ObjectStoreGatewayServer(
         request: GatewayOuterClass.FetchObjectRequest,
         responseObserver: StreamObserver<GatewayOuterClass.FetchObjectResponse>
     ) {
-        scopeFetchService.fetchScope(request.scopeAddress, publicKey(), request.granterAddress.takeIf { it.isNotBlank() }).let {
+        scopeFetchService.fetchScopeForGrantee(request.scopeAddress, publicKey(), request.granterAddress.takeIf { it.isNotBlank() }).let {
             responseObserver.onNext(
                 GatewayOuterClass.FetchObjectResponse.newBuilder()
                     .setScopeId(request.scopeAddress)
@@ -32,6 +32,12 @@ class ObjectStoreGatewayServer(
             )
         }
         responseObserver.onCompleted()
+    }
+
+    override fun grantScopePermission(
+        request: GatewayOuterClass.GrantScopePermissionRequest,
+        responseObserver: StreamObserver<GatewayOuterClass.GrantScopePermissionResponse>,
+    ) {
     }
 
     override fun putObject(

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/service/ScopePermissionsService.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/service/ScopePermissionsService.kt
@@ -1,0 +1,99 @@
+package tech.figure.objectstore.gateway.service
+
+import io.provenance.metadata.v1.ScopeResponse
+import mu.KLogging
+import org.springframework.stereotype.Service
+import tech.figure.objectstore.gateway.repository.ScopePermissionsRepository
+
+@Service
+class ScopePermissionsService(
+    private val accountAddresses: Set<String>,
+    private val scopeFetchService: ScopeFetchService,
+    private val scopePermissionsRepository: ScopePermissionsRepository,
+) {
+    private companion object : KLogging()
+
+    fun processAccessGrant(
+        scopeAddress: String,
+        granteeAddress: String,
+        grantSourceAddresses: List<String>,
+        additionalAuthorizedAddresses: List<String> = emptyList(),
+        grantId: String? = null,
+        providedScope: ScopeResponse? = null,
+        sourceDetails: String? = null,
+    ) {
+        val logPrefix = "[GATEWAY GRANT (${sourceDetails ?: ""})]:"
+        val scopeResponse = providedScope ?: scopeFetchService.fetchScope(
+            scopeAddress = scopeAddress,
+            includeSessions = true,
+        )
+        val granterAddress = findRegisteredScopeOwnerAddress(scopeResponse = scopeResponse) ?: run {
+            logger.info("$logPrefix Skipping grant.  No granter is registered for scope [$scopeAddress]")
+            return
+        }
+        // TODO: Add authz reverse lookup to attempt to find additional authorized addresses.  The scope's value owner
+        // may have granted other addresses the required privileges that should allow this to proceed
+        val authorizedAddresses = additionalAuthorizedAddresses + scopeResponse.scope.scope.valueOwnerAddress
+        if (authorizedAddresses.none { it in grantSourceAddresses }) {
+            logger.warn("$logPrefix Skipping grant. None of the authorized addresses $authorizedAddresses for this grant were in the addresses that requested it $grantSourceAddresses")
+            return
+        }
+        logger.info("$logPrefix Adding account [$granteeAddress] to access list for scope [$scopeAddress] with granter [$granterAddress]")
+        scopePermissionsRepository.addAccessPermission(
+            scopeAddress = scopeAddress,
+            granteeAddress = granteeAddress,
+            granterAddress = granterAddress,
+            grantId = grantId,
+        )
+    }
+
+    fun processAccessRevoke(
+        scopeAddress: String,
+        granteeAddress: String,
+        revokeSourceAddresses: List<String>,
+        additionalAuthorizedAddresses: List<String> = emptyList(),
+        grantId: String? = null,
+        providedScope: ScopeResponse? = null,
+        sourceDetails: String? = null,
+    ) {
+        val logPrefix = "[GATEWAY REVOKE (${sourceDetails ?: ""})]:"
+        val scopeResponse = providedScope ?: scopeFetchService.fetchScope(scopeAddress = scopeAddress)
+        // TODO: Add authz reverse lookup to attempt to find additional authorized addresses.  The scope's value owner
+        // may have granted other addresses the required privileges that should allow this to proceed
+        val authorizedAddresses = additionalAuthorizedAddresses + scopeResponse.scope.scope.valueOwnerAddress
+        if (authorizedAddresses.none { it in revokeSourceAddresses }) {
+            logger.info("$logPrefix Skipping revoke.None of the authorized addresses $authorizedAddresses for this revoke were in the addresses that requested it $revokeSourceAddresses")
+            return
+        }
+        logger.info("$logPrefix Revoking grants from grantee [$granteeAddress] for scope [$scopeAddress]${if (grantId != null) " with grant id [$grantId]" else ""}")
+        scopePermissionsRepository.revokeAccessPermission(
+            scopeAddress = scopeAddress,
+            granteeAddress = granteeAddress,
+            grantId = grantId,
+        )
+    }
+
+    /**
+     * Determines if the target scope contains a registered object store deserialization key.
+     *
+     * @param scopeResponse The response from the Provenance Blockchain that denotes all the values within a scope.
+     */
+    private fun findRegisteredScopeOwnerAddress(scopeResponse: ScopeResponse): String? {
+        scopeResponse.scope.scope.ownersList.firstOrNull { it.address.isWatchedAddress() }?.also {
+            return it.address
+        }
+        scopeResponse.scope.scope.dataAccessList.firstOrNull { it.isWatchedAddress() }?.also {
+            return it
+        }
+        scopeResponse.sessionsList.flatMap { it.session.partiesList }.firstOrNull { it.address.isWatchedAddress() }
+            ?.also {
+                return it.address
+            }
+        return null
+    }
+
+    /**
+     * Extension function to determine if the value is contained in the registered object store deserialization addresses.
+     */
+    private fun String?.isWatchedAddress(): Boolean = this in accountAddresses
+}

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/service/StreamEventHandlerService.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/service/StreamEventHandlerService.kt
@@ -4,8 +4,6 @@ import cosmos.crypto.secp256k1.Keys.PubKey
 import cosmos.tx.v1beta1.ServiceOuterClass.GetTxRequest
 import io.provenance.client.grpc.PbClient
 import io.provenance.eventstream.stream.models.TxEvent
-import io.provenance.metadata.v1.ScopeRequest
-import io.provenance.metadata.v1.ScopeResponse
 import io.provenance.scope.encryption.ecies.ECUtils
 import io.provenance.scope.encryption.util.getAddress
 import mu.KLogging
@@ -16,12 +14,10 @@ import tech.figure.objectstore.gateway.eventstream.AssetClassificationEvent
 import tech.figure.objectstore.gateway.eventstream.GatewayEvent
 import tech.figure.objectstore.gateway.eventstream.GatewayExpectedEventType
 import tech.figure.objectstore.gateway.extensions.checkNotNull
-import tech.figure.objectstore.gateway.repository.ScopePermissionsRepository
 
 @Service
 class StreamEventHandlerService(
-    private val accountAddresses: Set<String>,
-    private val scopePermissionsRepository: ScopePermissionsRepository,
+    private val scopePermissionsService: ScopePermissionsService,
     private val pbClient: PbClient,
     private val provenanceProperties: ProvenanceProperties,
 ) {
@@ -39,76 +35,25 @@ class StreamEventHandlerService(
         // does not fit the expected gateway event structure
         GatewayEvent.fromEventOrNull(event)?.also { gatewayEvent ->
             when (gatewayEvent.eventType) {
-                GatewayExpectedEventType.ACCESS_GRANT -> handleGatewayGrant(gatewayEvent)
-                GatewayExpectedEventType.ACCESS_REVOKE -> handleGatewayRevoke(gatewayEvent)
+                GatewayExpectedEventType.ACCESS_GRANT -> scopePermissionsService.processAccessGrant(
+                    scopeAddress = gatewayEvent.scopeAddress,
+                    granteeAddress = gatewayEvent.targetAccount,
+                    grantSourceAddresses = getSignerAddressesForTx(gatewayEvent.txHash),
+                    grantId = gatewayEvent.accessGrantId,
+                    sourceDetails = "source: $gatewayEvent",
+                )
+                GatewayExpectedEventType.ACCESS_REVOKE -> scopePermissionsService.processAccessRevoke(
+                    scopeAddress = gatewayEvent.scopeAddress,
+                    granteeAddress = gatewayEvent.targetAccount,
+                    revokeSourceAddresses = getSignerAddressesForTx(gatewayEvent.txHash),
+                    // Include the target account as an account that can revoke permissions.  Any account should be able
+                    // to revoke its own grants
+                    additionalAuthorizedAddresses = listOf(gatewayEvent.targetAccount),
+                    grantId = gatewayEvent.accessGrantId,
+                    sourceDetails = "source: $gatewayEvent",
+                )
             }
         } ?: handleAssetClassificationEvent(AssetClassificationEvent(event))
-    }
-
-    /**
-     * Uses a successfully-parsed gateway grant event to grant access to a scope's underlying records if all validation
-     * for the event's formation passes.
-     *
-     * @param gatewayEvent A wasm-emitted event that uses the gateway access grant event type.
-     */
-    private fun handleGatewayGrant(gatewayEvent: GatewayEvent) {
-        val scopeResponse = lookupScope(gatewayEvent.scopeAddress)
-        // Ensure that the referenced scope is owned in some way by one of the gateway's registered keys.
-        // This ensures that properly-stored scopes will be able to be successfully decrypted in future requests by
-        // the granted address.
-        val granterAddress = findRegisteredScopeOwnerAddress(scopeResponse) ?: run {
-            logger.info("Skipping $gatewayEvent not owned by any registered granters")
-            return
-        }
-        // Ensure that the scope's value owner signed for the transaction that emitted this wasm event.  This ensures
-        // that this access grant has been safely requested and should be made
-        getSignerAddressesForTx(gatewayEvent.txHash).also { signerAddresses ->
-            // TODO: Do a reverse lookup for authz grants from the scope owner to signers to allow requests not directly
-            // originating from the scope owner - will have to determine a list of which grants are accessible.
-            if (scopeResponse.scope.scope.valueOwnerAddress !in signerAddresses) {
-                // This is a warning because an event attempted to grant access without actually owning the reference
-                // scope.  This indicates a bad configuration or an attempt to hijack data access.
-                logger.warn("Skipping $gatewayEvent due to unrelated signers: $signerAddresses")
-                return
-            }
-        }
-        handleAccessGrant(
-            txHash = gatewayEvent.txHash,
-            scopeAddress = gatewayEvent.scopeAddress,
-            granterAddress = granterAddress,
-            granteeAddress = gatewayEvent.targetAccount,
-            grantId = gatewayEvent.accessGrantId,
-        )
-    }
-
-    /**
-     * Uses a successfully-parsed gateway revoke event to revoke access to a scope's underlying records from a target
-     * bech32 address if all validation for the event's formation passes.
-     *
-     * @param gatewayEvent A wasm-emitted event that uses the gateway access revoke event type.
-     */
-    private fun handleGatewayRevoke(gatewayEvent: GatewayEvent) {
-        // Ensure that the event was in a transaction signed by either the target account or the scope owner.  This
-        // validates that either the scope owner no longer wishes for the target account to have a grant, or that the
-        // target account itself wishes to remove its own access
-        getSignerAddressesForTx(gatewayEvent.txHash).also { signerAddresses ->
-            logger.info("Found signers for tx [${gatewayEvent.txHash}]: $signerAddresses")
-            // TODO: Do a reverse lookup for authz grants from the scope owner to signers to allow requests not directly
-            // originating from the scope owner - will have to determine a list of which grants are accessible.
-            if (
-                gatewayEvent.targetAccount !in signerAddresses &&
-                lookupScope(gatewayEvent.scopeAddress, includeSessions = false).scope.scope.valueOwnerAddress !in signerAddresses
-            ) {
-                logger.warn("Skipping $gatewayEvent for unrelated signers (not scope value owner or target address). Signers: $signerAddresses")
-                return
-            }
-        }
-        logger.info("[ACCESS REVOKE | Tx: ${gatewayEvent.txHash}]: Revoking account [${gatewayEvent.targetAccount}] from access list for scope [${gatewayEvent.scopeAddress}]${if (gatewayEvent.accessGrantId != null) " with grant ID [${gatewayEvent.accessGrantId}]" else ""}")
-        scopePermissionsRepository.revokeAccessPermission(
-            scopeAddress = gatewayEvent.scopeAddress,
-            granteeAddress = gatewayEvent.targetAccount,
-            grantId = gatewayEvent.accessGrantId,
-        )
     }
 
     /**
@@ -152,96 +97,16 @@ class StreamEventHandlerService(
             logger.debug("No way to determine which verifier event at tx hash [${event.txHash}] was targeting. The address was null")
             return
         }
-        // only handle events onboarded by registered key
-        val registeredAddress = event.findRegisteredScopeOwnerAddress()
-        if (registeredAddress == null) {
-            logger.info("Skipping event of type [${event.eventType}] for unrelated scope owner [${event.scopeOwnerAddress}]")
-            return
-        }
         when (event.eventType) {
-            AcContractEvent.ONBOARD_ASSET -> handleAccessGrant(
-                txHash = event.txHash,
+            AcContractEvent.ONBOARD_ASSET -> scopePermissionsService.processAccessGrant(
                 scopeAddress = event.scopeAddress.checkNotNull { "[ONBOARD ASSET | Tx: ${event.txHash}]: Expected the onboard asset event to include a scope address" },
-                granteeAddress = event.verifierAddress!!,
-                granterAddress = registeredAddress,
+                granteeAddress = event.verifierAddress.checkNotNull { "[ONBOARD ASSET | Tx: ${event.txHash}]: Expected the onboard asset event to include a verifier address" },
+                // The scope owner address is established in the contract by directly using the sender of the contract message,
+                // making this relatively safe.
+                grantSourceAddresses = listOfNotNull(event.scopeOwnerAddress),
+                sourceDetails = "Asset Classification Event from tx [${event.txHash}]",
             )
             else -> throw IllegalStateException("After all event checks, an unexpected event was attempted for processing. Tx hash: [${event.txHash}], event type: [${event.eventType}]")
         }
-    }
-
-    /**
-     * Fetches scope details for a given bech32 Provenance Blockchain scope address.
-     *
-     * @param scopeAddress The unique bech32 address that points to a pbc scope.
-     * @param includeSessions If true, session value for the scope will be fetched from the chain.  Useful for scope
-     * owner linking to the registered object store keys for deserialization during scope fetches.
-     */
-    private fun lookupScope(scopeAddress: String, includeSessions: Boolean = true): ScopeResponse = pbClient
-        .metadataClient
-        .scope(ScopeRequest.newBuilder().setScopeId(scopeAddress).setIncludeSessions(includeSessions).build())
-
-    private fun AssetClassificationEvent.findRegisteredScopeOwnerAddress(): String? = if (scopeOwnerAddress.isWatchedAddress()) {
-        scopeOwnerAddress
-    } else {
-        findRegisteredScopeOwnerAddress(
-            scopeResponse = lookupScope(
-                scopeAddress = scopeAddress
-                    ?: error("Asset Classification Event [${this.txHash}] did not include a scope address"),
-            )
-        )
-    }
-
-    /**
-     * Determines if the target scope contains a registered object store deserialization key.
-     *
-     * @param scopeResponse The response from the Provenance Blockchain that denotes all the values within a scope.
-     */
-    private fun findRegisteredScopeOwnerAddress(scopeResponse: ScopeResponse): String? {
-        scopeResponse.scope.scope.ownersList.firstOrNull { it.address.isWatchedAddress() }?.also {
-            return it.address
-        }
-        scopeResponse.scope.scope.dataAccessList.firstOrNull { it.isWatchedAddress() }?.also {
-            return it
-        }
-        scopeResponse.sessionsList.flatMap { it.session.partiesList }.firstOrNull { it.address.isWatchedAddress() }
-            ?.also {
-                return it.address
-            }
-        return null
-    }
-
-    /**
-     * Extension function to determine if the value is contained in the registered object store deserialization addresses.
-     */
-    private fun String?.isWatchedAddress(): Boolean = this in accountAddresses
-
-    /**
-     * Inserts the specified access information into the database.  This grants unfettered access to the given grantee
-     * for the target scope, so this function should be used only after verifying that this action was safely and
-     * properly requested.
-     *
-     * @param txHash The hash of the transaction that contained the event that caused this grant.
-     * @param scopeAddress The bech32 address of the target scope for which to grant access.
-     * @param granteeAddress The bech32 address of the target account for which to permit scope record access.
-     * @param granterAddress The bech32 address of the key that will be used to deserialize object store scope record data
-     * upon requests made by the grantee.
-     * @param grantId An optional parameter that denotes that only records with this specific grant ID should be deleted.
-     * If omitted, all records with this scopeAddress and granteeAddress combination will be deleted.
-     */
-    private fun handleAccessGrant(
-        txHash: String,
-        scopeAddress: String,
-        granteeAddress: String,
-        granterAddress: String,
-        grantId: String? = null,
-    ) {
-        // fetch scope and add all hashes to lookup? Or just add scope to lookup? (probably do all hashes in v2)
-        logger.info("[ACCESS GRANT | Tx: $txHash]: Adding account [$granteeAddress] to access list for scope [$scopeAddress] with granter [$granterAddress]")
-        scopePermissionsRepository.addAccessPermission(
-            scopeAddress = scopeAddress,
-            granteeAddress = granteeAddress,
-            granterAddress = granterAddress,
-            grantId = grantId,
-        )
     }
 }

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/helpers/ProvenanceAccountHelpers.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/helpers/ProvenanceAccountHelpers.kt
@@ -1,0 +1,21 @@
+package tech.figure.objectstore.gateway.helpers
+
+import io.provenance.hdwallet.bip39.MnemonicWords
+import io.provenance.hdwallet.ec.extensions.toJavaECKeyPair
+import io.provenance.hdwallet.wallet.Account
+import io.provenance.hdwallet.wallet.Wallet
+import io.provenance.scope.encryption.model.DirectKeyRef
+import io.provenance.scope.encryption.model.KeyRef
+
+fun genRandomAccount(): Account = Wallet.fromMnemonic(
+    hrp = "tp",
+    passphrase = "",
+    mnemonicWords = MnemonicWords.generate(strength = 256),
+    testnet = true,
+)["m/44'/1'/0'/0/0'"]
+
+val Account.bech32Address: String
+    get() = address.value
+
+val Account.keyRef: KeyRef
+    get() = keyPair.toJavaECKeyPair().let(::DirectKeyRef)

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/helpers/QueryHelpers.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/helpers/QueryHelpers.kt
@@ -22,9 +22,17 @@ fun queryGrantCount(
 fun queryGrantCount(
     scopeAddr: String,
     grantee: String,
+    grantId: String? = null,
 ): Long = transaction {
     ScopePermissionsTable.select {
         ScopePermissionsTable.scopeAddress.eq(scopeAddr)
             .and { ScopePermissionsTable.granteeAddress eq grantee }
+            .let { query ->
+                if (grantId != null) {
+                    query.and { ScopePermissionsTable.grantId.eq(grantId) }
+                } else {
+                    query
+                }
+            }
     }.count()
 }

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/helpers/QueryHelpers.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/helpers/QueryHelpers.kt
@@ -1,0 +1,30 @@
+package tech.figure.objectstore.gateway.helpers
+
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.transactions.transaction
+import tech.figure.objectstore.gateway.model.ScopePermissionsTable
+
+fun queryGrantCount(
+    scopeAddr: String,
+    grantee: String,
+    granter: String,
+    grantId: String? = null,
+): Long = transaction {
+    ScopePermissionsTable.select {
+        ScopePermissionsTable.scopeAddress.eq(scopeAddr)
+            .and { ScopePermissionsTable.granteeAddress eq grantee }
+            .and { ScopePermissionsTable.granterAddress eq granter }
+            .and { ScopePermissionsTable.grantId eq grantId }
+    }.count()
+}
+
+fun queryGrantCount(
+    scopeAddr: String,
+    grantee: String,
+): Long = transaction {
+    ScopePermissionsTable.select {
+        ScopePermissionsTable.scopeAddress.eq(scopeAddr)
+            .and { ScopePermissionsTable.granteeAddress eq grantee }
+    }.count()
+}

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/helpers/ScopeMockHelpers.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/helpers/ScopeMockHelpers.kt
@@ -1,0 +1,46 @@
+package tech.figure.objectstore.gateway.helpers
+
+import io.provenance.metadata.v1.Party
+import io.provenance.metadata.v1.PartyType
+import io.provenance.metadata.v1.ScopeResponse
+import io.provenance.metadata.v1.SessionWrapper
+import io.provenance.scope.util.MetadataAddress
+import java.util.UUID
+
+fun mockScopeResponse(
+    address: String = MetadataAddress.forScope(UUID.randomUUID()).toString(),
+    owners: Set<Pair<PartyType, String>> = emptySet(),
+    dataAccessAddresses: Set<String> = emptySet(),
+    valueOwnerAddress: String? = null,
+    sessionParties: Set<Pair<PartyType, String>> = emptySet(),
+): ScopeResponse = ScopeResponse.newBuilder().also { responseBuilder ->
+    responseBuilder.scopeBuilder.also { scopeBuilder ->
+        scopeBuilder.scopeIdInfoBuilder.scopeAddr = address
+        scopeBuilder.scopeBuilder.also { nestedScopeBuilder ->
+            owners.forEach { (role, address) ->
+                nestedScopeBuilder.addOwners(
+                    Party.newBuilder().also { partyBuilder ->
+                        partyBuilder.role = role
+                        partyBuilder.address = address
+                    }
+                )
+            }
+            nestedScopeBuilder.addAllDataAccess(dataAccessAddresses)
+            valueOwnerAddress?.also { nestedScopeBuilder.valueOwnerAddress = it }
+        }
+    }
+    if (sessionParties.isNotEmpty()) {
+        responseBuilder.addSessions(
+            SessionWrapper.newBuilder().also { session ->
+                sessionParties.forEach { (role, address) ->
+                    session.sessionBuilder.addParties(
+                        Party.newBuilder().also { partyBuilder ->
+                            partyBuilder.role = role
+                            partyBuilder.address = address
+                        }
+                    )
+                }
+            }
+        )
+    }
+}.build()

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServerTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServerTest.kt
@@ -18,9 +18,7 @@ import io.provenance.scope.encryption.ecies.ProvenanceKeyGenerator
 import io.provenance.scope.encryption.util.getAddress
 import io.provenance.scope.util.sha256String
 import io.provenance.scope.util.toByteString
-import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.deleteAll
-import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.jupiter.api.BeforeEach
@@ -39,6 +37,7 @@ import tech.figure.objectstore.gateway.helpers.getValidRequest
 import tech.figure.objectstore.gateway.helpers.keyRef
 import tech.figure.objectstore.gateway.helpers.mockScopeResponse
 import tech.figure.objectstore.gateway.helpers.objectFromParts
+import tech.figure.objectstore.gateway.helpers.queryGrantCount
 import tech.figure.objectstore.gateway.model.ScopePermissionsTable
 import tech.figure.objectstore.gateway.repository.ScopePermissionsRepository
 import tech.figure.objectstore.gateway.service.ObjectService
@@ -421,14 +420,12 @@ class ObjectStoreGatewayServerTest {
         grantee: String = defaultGrantee,
         granter: String = defaultGranter,
         grantId: String? = null,
-    ): Long = transaction {
-        ScopePermissionsTable.select {
-            ScopePermissionsTable.scopeAddress.eq(scopeAddr)
-                .and { ScopePermissionsTable.granteeAddress eq grantee }
-                .and { ScopePermissionsTable.granterAddress eq granter }
-                .and { ScopePermissionsTable.grantId eq grantId }
-        }.count()
-    }
+    ): Long = queryGrantCount(
+        scopeAddr = scopeAddr,
+        grantee = grantee,
+        granter = granter,
+        grantId = grantId,
+    )
 
     /**
      * Observer mocks will freak out and throw an exception when any of their standard response functions are called.

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServerTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServerTest.kt
@@ -7,39 +7,54 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verifyAll
 import io.provenance.scope.encryption.ecies.ProvenanceKeyGenerator
+import io.provenance.scope.encryption.model.KeyRef
 import io.provenance.scope.encryption.util.getAddress
 import io.provenance.scope.util.sha256String
 import io.provenance.scope.util.toByteString
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import tech.figure.objectstore.gateway.GatewayOuterClass
+import tech.figure.objectstore.gateway.configuration.ProvenanceProperties
 import tech.figure.objectstore.gateway.helpers.getValidFetchObjectByHashRequest
 import tech.figure.objectstore.gateway.helpers.getValidPutObjectRequest
 import tech.figure.objectstore.gateway.helpers.getValidRequest
 import tech.figure.objectstore.gateway.helpers.objectFromParts
 import tech.figure.objectstore.gateway.service.ObjectService
 import tech.figure.objectstore.gateway.service.ScopeFetchService
+import tech.figure.objectstore.gateway.service.ScopePermissionsService
 import java.security.KeyPair
 import kotlin.random.Random
 
 class ObjectStoreGatewayServerTest {
+    lateinit var masterKey: KeyRef
     lateinit var scopeFetchService: ScopeFetchService
+    lateinit var scopePermissionsService: ScopePermissionsService
     lateinit var objectService: ObjectService
+    lateinit var provenanceProperties: ProvenanceProperties
     val keyPair: KeyPair = ProvenanceKeyGenerator.generateKeyPair()
 
     lateinit var server: ObjectStoreGatewayServer
 
     @BeforeEach
     fun setUp() {
+        masterKey = mockk()
         scopeFetchService = mockk()
+        scopePermissionsService = mockk()
         objectService = mockk()
+        provenanceProperties = mockk()
 
         Context.current()
             .withValue(Constants.REQUESTOR_PUBLIC_KEY_CTX, keyPair.public)
             .withValue(Constants.REQUESTOR_ADDRESS_CTX, keyPair.public.getAddress(false))
             .attach()
 
-        server = ObjectStoreGatewayServer(scopeFetchService, objectService)
+        server = ObjectStoreGatewayServer(
+            masterKey = masterKey,
+            scopeFetchService = scopeFetchService,
+            scopePermissionsService = scopePermissionsService,
+            objectService = objectService,
+            provenanceProperties = provenanceProperties,
+        )
     }
 
     @Test

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServerTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServerTest.kt
@@ -1,55 +1,93 @@
 package tech.figure.objectstore.gateway.server
 
 import Constants
+import com.google.protobuf.Message
 import io.grpc.Context
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
 import io.grpc.stub.StreamObserver
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
 import io.mockk.verifyAll
+import io.provenance.hdwallet.ec.extensions.toJavaECKeyPair
+import io.provenance.hdwallet.wallet.Account
+import io.provenance.metadata.v1.PartyType
 import io.provenance.scope.encryption.ecies.ProvenanceKeyGenerator
-import io.provenance.scope.encryption.model.KeyRef
 import io.provenance.scope.encryption.util.getAddress
 import io.provenance.scope.util.sha256String
 import io.provenance.scope.util.toByteString
+import org.jetbrains.exposed.sql.deleteAll
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
 import tech.figure.objectstore.gateway.GatewayOuterClass
+import tech.figure.objectstore.gateway.GatewayOuterClass.GrantScopePermissionRequest
+import tech.figure.objectstore.gateway.GatewayOuterClass.GrantScopePermissionResponse
 import tech.figure.objectstore.gateway.configuration.ProvenanceProperties
+import tech.figure.objectstore.gateway.helpers.genRandomAccount
 import tech.figure.objectstore.gateway.helpers.getValidFetchObjectByHashRequest
 import tech.figure.objectstore.gateway.helpers.getValidPutObjectRequest
 import tech.figure.objectstore.gateway.helpers.getValidRequest
+import tech.figure.objectstore.gateway.helpers.keyRef
+import tech.figure.objectstore.gateway.helpers.mockScopeResponse
 import tech.figure.objectstore.gateway.helpers.objectFromParts
+import tech.figure.objectstore.gateway.model.ScopePermissionsTable
+import tech.figure.objectstore.gateway.repository.ScopePermissionsRepository
 import tech.figure.objectstore.gateway.service.ObjectService
 import tech.figure.objectstore.gateway.service.ScopeFetchService
 import tech.figure.objectstore.gateway.service.ScopePermissionsService
 import java.security.KeyPair
 import kotlin.random.Random
+import kotlin.test.assertEquals
 
+@SpringBootTest
 class ObjectStoreGatewayServerTest {
-    lateinit var masterKey: KeyRef
     lateinit var scopeFetchService: ScopeFetchService
     lateinit var scopePermissionsService: ScopePermissionsService
+    lateinit var scopePermissionsRepository: ScopePermissionsRepository
     lateinit var objectService: ObjectService
     lateinit var provenanceProperties: ProvenanceProperties
     val keyPair: KeyPair = ProvenanceKeyGenerator.generateKeyPair()
+    val masterAccount: Account = genRandomAccount()
 
     lateinit var server: ObjectStoreGatewayServer
 
+    val defaultGranter: String = "accessGranter"
+    val scopeAddress = "scopeAddress"
+    val defaultGrantee = "grantee"
+
     @BeforeEach
-    fun setUp() {
-        masterKey = mockk()
+    fun clearDb() {
+        transaction { ScopePermissionsTable.deleteAll() }
+    }
+
+    fun setUpBaseServices(
+        accountAddresses: Set<String> = setOf(defaultGranter),
+        contextKeyPair: KeyPair = keyPair,
+    ) {
         scopeFetchService = mockk()
-        scopePermissionsService = mockk()
+        scopePermissionsRepository = ScopePermissionsRepository()
         objectService = mockk()
         provenanceProperties = mockk()
 
+        every { provenanceProperties.mainNet } returns false
+
         Context.current()
-            .withValue(Constants.REQUESTOR_PUBLIC_KEY_CTX, keyPair.public)
-            .withValue(Constants.REQUESTOR_ADDRESS_CTX, keyPair.public.getAddress(false))
+            .withValue(Constants.REQUESTOR_PUBLIC_KEY_CTX, contextKeyPair.public)
+            .withValue(Constants.REQUESTOR_ADDRESS_CTX, contextKeyPair.public.getAddress(false))
             .attach()
 
+        scopePermissionsService = ScopePermissionsService(
+            accountAddresses = accountAddresses,
+            scopeFetchService = scopeFetchService,
+            scopePermissionsRepository = scopePermissionsRepository,
+        )
         server = ObjectStoreGatewayServer(
-            masterKey = masterKey,
+            masterKey = masterAccount.keyRef,
             scopeFetchService = scopeFetchService,
             scopePermissionsService = scopePermissionsService,
             objectService = objectService,
@@ -57,10 +95,22 @@ class ObjectStoreGatewayServerTest {
         )
     }
 
+    fun setUpScopePermissionValues() {
+        every { scopeFetchService.fetchScope(any(), any(), any()) } returns mockScopeResponse(
+            address = scopeAddress,
+            owners = setOf(
+                PartyType.PARTY_TYPE_OWNER to keyPair.public.getAddress(false),
+                PartyType.PARTY_TYPE_AFFILIATE to defaultGranter,
+            ),
+            valueOwnerAddress = keyPair.public.getAddress(false),
+        )
+    }
+
     @Test
     fun `fetchObject should succeed with a valid request`() {
+        setUpBaseServices()
         val request = getValidRequest()
-        val responseObserver: StreamObserver<GatewayOuterClass.FetchObjectResponse> = mockk()
+        val responseObserver: StreamObserver<GatewayOuterClass.FetchObjectResponse> = mockkObserver()
 
         val dummyRecords = listOf(
             GatewayOuterClass.Record.newBuilder()
@@ -71,9 +121,6 @@ class ObjectStoreGatewayServerTest {
         )
 
         every { scopeFetchService.fetchScopeForGrantee(request.scopeAddress, keyPair.public, request.granterAddress.takeIf { it.isNotBlank() }) } returns dummyRecords
-
-        every { responseObserver.onNext(any()) } returns mockk()
-        every { responseObserver.onCompleted() } returns mockk()
 
         server.fetchObject(request, responseObserver)
 
@@ -90,22 +137,21 @@ class ObjectStoreGatewayServerTest {
 
     @Test
     fun `putObject should succeed with a valid request without type`() {
+        setUpBaseServices()
         testSuccessfulPutObject(getValidPutObjectRequest())
     }
 
     @Test
     fun `putObject should succeed with a valid request with type`() {
+        setUpBaseServices()
         testSuccessfulPutObject(getValidPutObjectRequest("cool_type"))
     }
 
     fun testSuccessfulPutObject(request: GatewayOuterClass.PutObjectRequest) {
-        val responseObserver: StreamObserver<GatewayOuterClass.PutObjectResponse> = mockk()
+        val responseObserver: StreamObserver<GatewayOuterClass.PutObjectResponse> = mockkObserver()
 
         val byteHash = request.`object`.toByteArray().sha256String()
         every { objectService.putObject(request.`object`, keyPair.public) } returns byteHash
-
-        every { responseObserver.onNext(any()) } returns mockk()
-        every { responseObserver.onCompleted() } returns mockk()
 
         server.putObject(request, responseObserver)
 
@@ -121,24 +167,23 @@ class ObjectStoreGatewayServerTest {
 
     @Test
     fun `getObjectByHash should return object with no type`() {
+        setUpBaseServices()
         testSuccessfulGetObjectByHash(Random.nextBytes(100))
     }
 
     @Test
     fun `getObjectByHash should return object with type`() {
+        setUpBaseServices()
         testSuccessfulGetObjectByHash(Random.nextBytes(100), "my_type")
     }
 
     fun testSuccessfulGetObjectByHash(objectBytes: ByteArray, type: String? = null) {
-        val responseObserver: StreamObserver<GatewayOuterClass.FetchObjectByHashResponse> = mockk()
+        val responseObserver = mockkObserver<GatewayOuterClass.FetchObjectByHashResponse>()
         val ownerAddress = keyPair.public.getAddress(false)
         val obj = objectFromParts(objectBytes, type)
 
         val byteHash = objectBytes.sha256String()
         every { objectService.getObject(byteHash, ownerAddress) } returns obj
-
-        every { responseObserver.onNext(any()) } returns mockk()
-        every { responseObserver.onCompleted() } returns mockk()
 
         server.fetchObjectByHash(getValidFetchObjectByHashRequest(byteHash), responseObserver)
 
@@ -150,5 +195,132 @@ class ObjectStoreGatewayServerTest {
             )
             responseObserver.onCompleted()
         }
+    }
+
+    @Test
+    fun `grantScopePermission should respond with the granter address used on a successful grant with authorized granter`() {
+        setUpBaseServices()
+        setUpScopePermissionValues()
+        val responseObserver = mockkObserver<GrantScopePermissionResponse>()
+        val request = getDefaultPermissionGrant()
+        server.grantScopePermission(request = request, responseObserver = responseObserver)
+        verify(inverse = true) { responseObserver.onError(any()) }
+        verifyAll {
+            responseObserver.onNext(
+                GrantScopePermissionResponse.newBuilder().also { response ->
+                    response.request = request
+                    response.granterAddress = defaultGranter
+                    response.grantAccepted = true
+                }.build()
+            )
+            responseObserver.onCompleted()
+        }
+        assertEquals(
+            expected = listOf(defaultGranter),
+            actual = scopePermissionsRepository.getAccessGranterAddresses(
+                scopeAddress = scopeAddress,
+                granteeAddress = defaultGrantee,
+            ),
+            message = "The access grant should be added to the permissions table",
+        )
+    }
+
+    @Test
+    fun `grantScopePermission should respond with the granter address used on a successful grant with the master key`() {
+        setUpBaseServices(contextKeyPair = masterAccount.keyPair.toJavaECKeyPair())
+        setUpScopePermissionValues()
+        val responseObserver = mockkObserver<GrantScopePermissionResponse>()
+        val request = getDefaultPermissionGrant()
+        server.grantScopePermission(request = request, responseObserver = responseObserver)
+        verify(inverse = true) { responseObserver.onError(any()) }
+        verifyAll {
+            responseObserver.onNext(
+                GrantScopePermissionResponse.newBuilder().also { response ->
+                    response.request = request
+                    response.granterAddress = defaultGranter
+                    response.grantAccepted = true
+                }.build()
+            )
+            responseObserver.onCompleted()
+        }
+        assertEquals(
+            expected = listOf(defaultGranter),
+            actual = scopePermissionsRepository.getAccessGranterAddresses(
+                scopeAddress = scopeAddress,
+                granteeAddress = defaultGrantee,
+            ),
+            message = "The access grant should be added to the permissions table",
+        )
+    }
+
+    @Test
+    fun `grantScopePermission should reject grants that are not authorized`() {
+        // Use some random account as the requesting account to verify that the requester has to be someone relevant
+        setUpBaseServices(contextKeyPair = genRandomAccount().keyPair.toJavaECKeyPair())
+        setUpScopePermissionValues()
+        val responseObserver = mockkObserver<GrantScopePermissionResponse>()
+        val request = getDefaultPermissionGrant()
+        server.grantScopePermission(request = request, responseObserver = responseObserver)
+        verify(inverse = true) { responseObserver.onError(any()) }
+        verifyAll {
+            responseObserver.onNext(
+                GrantScopePermissionResponse.newBuilder().also { response ->
+                    response.request = request
+                    response.grantAccepted = false
+                }.build()
+            )
+            responseObserver.onCompleted()
+        }
+        assertEquals(
+            expected = 0,
+            actual = transaction { ScopePermissionsTable.selectAll().count() },
+            message = "No scope permissions should have ever been assigned, proving that the grant was rejected",
+        )
+    }
+
+    @Test
+    fun `grantScopePermission should return expected unknown response on exception`() {
+        setUpBaseServices()
+        // Setup scope fetch service to freak out, simulating a provenance communication error
+        val expectedException = IllegalStateException("Provenance is actin' up again")
+        every { scopeFetchService.fetchScope(any(), any(), any()) } throws expectedException
+        val responseObserver = mockkObserver<GrantScopePermissionResponse>()
+        val exceptionSlot = slot<StatusRuntimeException>()
+        every { responseObserver.onError(capture(exceptionSlot)) } returns Unit
+        server.grantScopePermission(request = getDefaultPermissionGrant(), responseObserver = responseObserver)
+        verifyAll(inverse = true) {
+            responseObserver.onNext(any())
+            responseObserver.onCompleted()
+        }
+        assertEquals(
+            expected = Status.UNKNOWN.code,
+            actual = exceptionSlot.captured.status.code,
+            message = "The UNKNOWN status should be emitted when an exception is encountered",
+        )
+        assertEquals(
+            expected = expectedException,
+            actual = exceptionSlot.captured.status.cause,
+            message = "The expected exception should be used as the cause by the captured error",
+        )
+    }
+
+    private fun getDefaultPermissionGrant(
+        grantee: String = defaultGrantee,
+        grantId: String? = null
+    ): GrantScopePermissionRequest = GrantScopePermissionRequest.newBuilder().also { reqBuilder ->
+        reqBuilder.scopeAddress = scopeAddress
+        reqBuilder.granteeAddress = grantee
+        grantId?.also { reqBuilder.grantId = it }
+    }.build()
+
+    /**
+     * Observer mocks will freak out and throw an exception when any of their standard response functions are called.
+     * This function will inline create a StreamObserver for the rpc message requested, ensuring that all its relevant
+     * functions utilized in this application are mocked out.
+     */
+    private inline fun <reified T : Message> mockkObserver(): StreamObserver<T> = mockk<StreamObserver<T>>().also { observer ->
+        every { observer.onNext(any()) } returns Unit
+        every { observer.onError(any()) } returns Unit
+        every { observer.onCompleted() } returns Unit
     }
 }

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServerTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServerTest.kt
@@ -55,7 +55,7 @@ class ObjectStoreGatewayServerTest {
                 .build()
         )
 
-        every { scopeFetchService.fetchScope(request.scopeAddress, keyPair.public, request.granterAddress.takeIf { it.isNotBlank() }) } returns dummyRecords
+        every { scopeFetchService.fetchScopeForGrantee(request.scopeAddress, keyPair.public, request.granterAddress.takeIf { it.isNotBlank() }) } returns dummyRecords
 
         every { responseObserver.onNext(any()) } returns mockk()
         every { responseObserver.onCompleted() } returns mockk()

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/service/ScopeFetchServiceTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/service/ScopeFetchServiceTest.kt
@@ -106,7 +106,7 @@ class ScopeFetchServiceTest {
         every { scopePermissionsRepository.getAccessGranterAddresses(scopeAddress, requesterAddress) } returns listOf()
 
         val exception = assertThrows<AccessDeniedException> {
-            service.fetchScope(scopeAddress, encryptionPublicKey, null)
+            service.fetchScopeForGrantee(scopeAddress, encryptionPublicKey, null)
         }
 
         assertNotNull(exception.status.description)
@@ -117,7 +117,7 @@ class ScopeFetchServiceTest {
     fun `fetchScope should allow access for a scope owner even when no scope access is set up and owner is in encryption keys`() {
         val encryptionPublicKey = scopeOwnerKey.second.publicKey
 
-        val records = service.fetchScope(scopeAddress, encryptionPublicKey, null)
+        val records = service.fetchScopeForGrantee(scopeAddress, encryptionPublicKey, null)
 
         assertEquals(2, records.size)
         records.forEachIndexed { i, record ->
@@ -139,7 +139,7 @@ class ScopeFetchServiceTest {
         every { scopePermissionsRepository.getAccessGranterAddresses(scopeAddress, requesterAddress) } returns listOf(granterAddress)
 
         val exception = assertThrows<AccessDeniedException> {
-            service.fetchScope(scopeAddress, encryptionPublicKey, null)
+            service.fetchScopeForGrantee(scopeAddress, encryptionPublicKey, null)
         }
 
         assertNotNull(exception.status.description)
@@ -153,7 +153,7 @@ class ScopeFetchServiceTest {
         every { pbClient.metadataClient.scope(any()) } returns scopeResponse
         every { scopePermissionsRepository.getAccessGranterAddresses(scopeAddress, scopeOwnerAddress) } returns emptyList()
         val exception = assertThrows<AccessDeniedException> {
-            service.fetchScope(scopeAddress, scopeOwnerKeyRef.publicKey, null)
+            service.fetchScopeForGrantee(scopeAddress, scopeOwnerKeyRef.publicKey, null)
         }
         assertNotNull(exception.status.description)
         assertContains(exception.status.description!!, "Scope access not granted to $scopeOwnerAddress")
@@ -166,7 +166,7 @@ class ScopeFetchServiceTest {
         every { pbClient.metadataClient.scope(any()) } returns scopeResponse
         every { scopePermissionsRepository.getAccessGranterAddresses(scopeAddress, encryptionKeyPair.first) } returns emptyList()
         val exception = assertThrows<AccessDeniedException> {
-            service.fetchScope(scopeAddress, encryptionKeyPair.second.publicKey, null)
+            service.fetchScopeForGrantee(scopeAddress, encryptionKeyPair.second.publicKey, null)
         }
         assertNotNull(exception.status.description)
         assertContains(exception.status.description!!, "Scope access not granted to ${encryptionKeyPair.first}")

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/service/ScopePermissionsServiceTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/service/ScopePermissionsServiceTest.kt
@@ -1,0 +1,267 @@
+package tech.figure.objectstore.gateway.service
+
+import io.mockk.every
+import io.mockk.mockk
+import io.provenance.hdwallet.wallet.Account
+import io.provenance.metadata.v1.PartyType
+import io.provenance.metadata.v1.ScopeResponse
+import io.provenance.scope.util.MetadataAddress
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import tech.figure.objectstore.gateway.helpers.bech32Address
+import tech.figure.objectstore.gateway.helpers.genRandomAccount
+import tech.figure.objectstore.gateway.helpers.mockScopeResponse
+import tech.figure.objectstore.gateway.helpers.queryGrantCount
+import tech.figure.objectstore.gateway.repository.ScopePermissionsRepository
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@SpringBootTest
+class ScopePermissionsServiceTest {
+    // Services
+    lateinit var scopeFetchService: ScopeFetchService
+    lateinit var scopePermissionsRepository: ScopePermissionsRepository
+    lateinit var service: ScopePermissionsService
+
+    // Addresses
+    private val scopeOwner: Account = genRandomAccount()
+    private val scopeAddress: String = MetadataAddress.forScope(UUID.randomUUID()).toString()
+    private val ownerGranter: String = "ownerGranter"
+    private val dataAccessGranter: String = "dataAccessGranter"
+    private val sessionGranter: String = "sessionGranter"
+    private val defaultGrantee: String = "grantee"
+
+    fun setUp(
+        accountAddresses: Set<String> = setOf(ownerGranter),
+        scopeResponse: ScopeResponse = mockScopeResponse(
+            address = scopeAddress,
+            owners = setOf(
+                PartyType.PARTY_TYPE_OWNER to scopeOwner.bech32Address,
+                PartyType.PARTY_TYPE_INVESTOR to ownerGranter,
+            ),
+            dataAccessAddresses = setOf(dataAccessGranter),
+            valueOwnerAddress = scopeOwner.bech32Address,
+            sessionParties = setOf(PartyType.PARTY_TYPE_ORIGINATOR to sessionGranter),
+        ),
+    ) {
+        scopeFetchService = mockk()
+        scopePermissionsRepository = ScopePermissionsRepository()
+        every { scopeFetchService.fetchScope(any(), any(), any()) } returns scopeResponse
+        service = ScopePermissionsService(
+            accountAddresses = accountAddresses,
+            scopeFetchService = scopeFetchService,
+            scopePermissionsRepository = scopePermissionsRepository,
+        )
+    }
+
+    @Test
+    fun `processAccessGrant rejects request that has no registered owner`() {
+        // Establish the registered accounts as a set of a random address unrelated to anything else
+        setUp(accountAddresses = setOf(genRandomAccount().bech32Address))
+        val response = service.processAccessGrant(
+            scopeAddress = scopeAddress,
+            granteeAddress = defaultGrantee,
+            grantSourceAddresses = setOf(scopeOwner.bech32Address),
+        )
+        assertTrue(
+            actual = response is GrantResponse.Rejected,
+            message = "The response should be a rejected response, but got type: ${response::class.qualifiedName}",
+        )
+        assertTrue(
+            actual = "Skipping grant.  No granter is registered for scope [$scopeAddress]" in response.message,
+            message = "Expected the correct rejection message to be included, but got: ${response.message}",
+        )
+    }
+
+    @Test
+    fun `processAccessGrant rejects request from unauthorized source`() {
+        setUp()
+        val response = service.processAccessGrant(
+            scopeAddress = scopeAddress,
+            granteeAddress = defaultGrantee,
+            grantSourceAddresses = setOf(genRandomAccount().bech32Address),
+        )
+        assertTrue(
+            response is GrantResponse.Rejected,
+            message = "The response should be a rejected response, but got type: ${response::class.qualifiedName}",
+        )
+        assertTrue(
+            actual = "Skipping grant. None of the authorized addresses [${scopeOwner.bech32Address}] for this grant were in the addresses that requested it" in response.message,
+            message = "Expected the correct rejection message to be included, but got: ${response.message}",
+        )
+    }
+
+    @Test
+    fun `processAccessGrant returns error when an exception is thrown`() {
+        setUp()
+        val expectedException = IllegalStateException("Oh, no! A thing happened!")
+        every { scopeFetchService.fetchScope(any(), any(), any()) } throws expectedException
+        val response = service.processAccessGrant(
+            scopeAddress = scopeAddress,
+            granteeAddress = defaultGrantee,
+            grantSourceAddresses = setOf(scopeOwner.bech32Address),
+        )
+        assertTrue(
+            actual = response is GrantResponse.Error,
+            message = "The response should be an error response, but got type: ${response::class.qualifiedName}",
+        )
+        assertEquals(
+            expected = expectedException,
+            actual = response.cause,
+            message = "The returned exception should be the expected value",
+        )
+    }
+
+    @Test
+    fun `processAccessGrant accepts request from scope owner`() {
+        setUp()
+        val response = service.processAccessGrant(
+            scopeAddress = scopeAddress,
+            granteeAddress = defaultGrantee,
+            grantSourceAddresses = setOf(scopeOwner.bech32Address),
+        )
+        assertGrantResponseAccepted(response)
+    }
+
+    @Test
+    fun `processAccessGrant accepts request from additional authorized address`() {
+        setUp()
+        val authorizedAccount = genRandomAccount()
+        val response = service.processAccessGrant(
+            scopeAddress = scopeAddress,
+            granteeAddress = defaultGrantee,
+            grantSourceAddresses = setOf(authorizedAccount.bech32Address),
+            additionalAuthorizedAddresses = setOf(authorizedAccount.bech32Address),
+        )
+        assertGrantResponseAccepted(response)
+    }
+
+    @Test
+    fun `processAccessGrant accepts request with grant id and creates proper record`() {
+        setUp()
+        val response = service.processAccessGrant(
+            scopeAddress = scopeAddress,
+            granteeAddress = defaultGrantee,
+            grantSourceAddresses = setOf(scopeOwner.bech32Address),
+            grantId = "my-grant-id",
+        )
+        assertGrantResponseAccepted(response = response, expectedGrantId = "my-grant-id")
+    }
+
+    @Test
+    fun `processAccessRevoke rejects request from unauthorized source`() {
+        setUp()
+        val response = service.processAccessRevoke(
+            scopeAddress = scopeAddress,
+            granteeAddress = defaultGrantee,
+            revokeSourceAddresses = setOf(genRandomAccount().bech32Address),
+        )
+        assertTrue(
+            actual = response is RevokeResponse.Rejected,
+            message = "The response should be a rejected response, but got type: ${response::class.qualifiedName}",
+        )
+        assertTrue(
+            actual = "Skipping revoke.  None of the authorized addresses [${scopeOwner.bech32Address}] for this revoke were in the addresses that requested it" in response.message,
+            message = "Expected the correct rejection message to be included, but got: ${response.message}",
+        )
+    }
+
+    @Test
+    fun `processAccessRevoke returns error when an exception is thrown`() {
+        setUp()
+        val expectedException = IllegalArgumentException("Stop arguing with me")
+        every { scopeFetchService.fetchScope(any(), any(), any()) } throws expectedException
+        val response = service.processAccessRevoke(
+            scopeAddress = scopeAddress,
+            granteeAddress = defaultGrantee,
+            revokeSourceAddresses = setOf(scopeOwner.bech32Address),
+        )
+        assertTrue(
+            actual = response is RevokeResponse.Error,
+            message = "The response should be an error response, but got type: ${response::class.qualifiedName}",
+        )
+        assertEquals(
+            expected = expectedException,
+            actual = response.cause,
+            message = "The returned exception should be the expected value",
+        )
+    }
+
+    @Test
+    fun `processAccessRevoke accepts revoke from scope owner`() {
+        setUp()
+        service.processAccessGrant(
+            scopeAddress = scopeAddress,
+            granteeAddress = defaultGrantee,
+            grantSourceAddresses = setOf(scopeOwner.bech32Address),
+        ).also(::assertGrantResponseAccepted)
+        service.processAccessRevoke(
+            scopeAddress = scopeAddress,
+            granteeAddress = defaultGrantee,
+            revokeSourceAddresses = setOf(scopeOwner.bech32Address),
+        ).also(::assertRevokeResponseAccepted)
+    }
+
+    private fun assertGrantResponseAccepted(
+        response: GrantResponse,
+        expectedGranter: String = ownerGranter,
+        expectedScopeAddress: String = scopeAddress,
+        expectedGrantee: String = defaultGrantee,
+        expectedGrantId: String? = null,
+    ) {
+        assertTrue(
+            actual = response is GrantResponse.Accepted,
+            message = "The response should be an accepted response, but got type: ${response::class.qualifiedName}",
+        )
+        assertEquals(
+            expected = expectedGranter,
+            actual = response.granterAddress,
+            message = "The correct granter should be used",
+        )
+        assertEquals(
+            expected = 1,
+            actual = getGrantCount(
+                scopeAddr = expectedScopeAddress,
+                grantee = expectedGrantee,
+                granter = expectedGranter,
+                grantId = expectedGrantId,
+            ),
+            message = "Expected a grant with the proper specifications to be created after an accepted request",
+        )
+    }
+
+    private fun assertRevokeResponseAccepted(
+        response: RevokeResponse,
+        grantScopeAddress: String = scopeAddress,
+        granteeAddress: String = defaultGrantee,
+        expectedRevokedGrantsCount: Int = 1,
+    ) {
+        assertTrue(
+            actual = response is RevokeResponse.Accepted,
+            message = "The response should be an accepted response, but got type: ${response::class.qualifiedName}",
+        )
+        assertEquals(
+            expected = expectedRevokedGrantsCount,
+            actual = response.revokedGrantsCount,
+            message = "Expected a different number of grants to be revoked",
+        )
+        assertEquals(
+            expected = 0,
+            actual = queryGrantCount(scopeAddr = grantScopeAddress, grantee = granteeAddress),
+            message = "Expected no grants with the specified scope address to remain",
+        )
+    }
+
+    private fun getGrantCount(
+        scopeAddr: String = scopeAddress,
+        grantee: String = defaultGrantee,
+        granter: String = ownerGranter,
+        grantId: String? = null,
+    ): Long = queryGrantCount(
+        scopeAddr = scopeAddr,
+        grantee = grantee,
+        granter = granter,
+        grantId = grantId,
+    )
+}

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/service/StreamEventHandlerServiceTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/service/StreamEventHandlerServiceTest.kt
@@ -34,7 +34,6 @@ import java.time.OffsetDateTime
 import java.util.Base64
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 import kotlin.test.fail
 
 @SpringBootTest
@@ -288,84 +287,6 @@ class StreamEventHandlerServiceTest {
     }
 
     @Test
-    fun `StreamEventHandlerService removes any and disregards grant id when revoke expression does not include it`() {
-        setUp()
-
-        val firstGrantId = "the best grant ever"
-        val secondGrantId = "the betterest grant ever"
-        val thirdGrantId = "I don't even have a fake adjective for this one"
-
-        submitGatewayEvent(GatewayExpectedEventType.ACCESS_GRANT, grantId = firstGrantId)
-        submitGatewayEvent(GatewayExpectedEventType.ACCESS_GRANT, grantId = secondGrantId)
-        submitGatewayEvent(GatewayExpectedEventType.ACCESS_GRANT, grantId = thirdGrantId)
-        submitGatewayEvent(GatewayExpectedEventType.ACCESS_GRANT, grantId = null)
-
-        assertScopePermissionExists(grantId = firstGrantId)
-        assertScopePermissionExists(grantId = secondGrantId)
-        assertScopePermissionExists(grantId = thirdGrantId)
-        assertScopePermissionExists(grantId = null)
-
-        submitGatewayEvent(GatewayExpectedEventType.ACCESS_REVOKE)
-
-        assertScopePermissionDoesNotExist(grantId = firstGrantId, messagePrefix = "The first grant should be removed after an access revoke does not supply a grant id")
-        assertScopePermissionDoesNotExist(grantId = secondGrantId, messagePrefix = "The second grant should be removed after an access revoke does not supply a grant id")
-        assertScopePermissionDoesNotExist(grantId = thirdGrantId, messagePrefix = "The third grant should be removed after an access revoke does not supply a grant id")
-        assertScopePermissionDoesNotExist(grantId = null, messagePrefix = "The null id grant should be removed after an access revoke does not supply a grant id")
-
-        assertEquals(
-            expected = emptyList(),
-            actual = scopePermissionsRepository.getAccessGranterAddresses(scopeAddress, grantee.bech32Address),
-            message = "All grants should be removed when the revocation does not supply a targeted grant id",
-        )
-    }
-
-    @Test
-    fun `StreamEventHandlerService removes grant id specifically upon request`() {
-        setUp()
-
-        val firstGrantId = "first-grant"
-        val secondGrantId = "second-grant"
-
-        submitGatewayEvent(GatewayExpectedEventType.ACCESS_GRANT, grantId = firstGrantId)
-        submitGatewayEvent(GatewayExpectedEventType.ACCESS_GRANT, grantId = secondGrantId)
-        submitGatewayEvent(GatewayExpectedEventType.ACCESS_GRANT)
-
-        assertScopePermissionExists(grantId = firstGrantId)
-        assertScopePermissionExists(grantId = secondGrantId)
-        assertScopePermissionExists(grantId = null)
-
-        submitGatewayEvent(GatewayExpectedEventType.ACCESS_REVOKE, grantId = "other grant id")
-
-        assertScopePermissionExists(grantId = firstGrantId, messagePrefix = "First grant should still exist after targeting a nonexistent grant id")
-        assertScopePermissionExists(grantId = secondGrantId, messagePrefix = "Second grant should still exist after targeting a nonexistent grant id")
-        assertScopePermissionExists(grantId = null, messagePrefix = "Null id grant should still exist after targeting a nonexistent grant id")
-
-        submitGatewayEvent(GatewayExpectedEventType.ACCESS_REVOKE, grantId = firstGrantId)
-
-        assertScopePermissionDoesNotExist(grantId = firstGrantId, messagePrefix = "First grant should be deleted after an access revoke requested it")
-        assertScopePermissionExists(grantId = secondGrantId, messagePrefix = "Second grant should still exist after only deleting the first grant id's record")
-        assertScopePermissionExists(grantId = null, messagePrefix = "Null id grant should still exist after only deleting the first grant id's record")
-
-        submitGatewayEvent(GatewayExpectedEventType.ACCESS_REVOKE, grantId = secondGrantId)
-
-        assertScopePermissionDoesNotExist(grantId = firstGrantId, messagePrefix = "First grant should remain deleted after deleting the second grant")
-        assertScopePermissionDoesNotExist(grantId = secondGrantId, messagePrefix = "Second grant should be deleted after an access revoke requested it")
-        assertScopePermissionExists(grantId = null, messagePrefix = "Null id grant should still exist after only deleting the second grant id's record")
-
-        submitGatewayEvent(GatewayExpectedEventType.ACCESS_REVOKE)
-
-        assertScopePermissionDoesNotExist(grantId = firstGrantId, messagePrefix = "First grant should remain deleted after removing grants with a null grant id")
-        assertScopePermissionDoesNotExist(grantId = secondGrantId, messagePrefix = "Second grant should remain deleted after removing grants with a null grant id")
-        assertScopePermissionDoesNotExist(grantId = null, messagePrefix = "Null id grant should be deleted after an access revoke requested all grants to be deleted")
-
-        assertEquals(
-            expected = emptyList(),
-            actual = scopePermissionsRepository.getAccessGranterAddresses(scopeAddress, grantee.bech32Address),
-            message = "After all grants have been deleted, no granter addresses should be available to the grantee",
-        )
-    }
-
-    @Test
     fun `StreamEventHandlerService gracefully handles unrelated access revoke`() {
         setUp()
 
@@ -445,24 +366,6 @@ class StreamEventHandlerServiceTest {
             message = "${messagePrefix ?: "Scope permission does not exist"}: Expected scope permission with scope address [$targetScopeAddress], granter [$granterAddress], grantee [$granteeAddress], and grant ID [$grantId] to exist",
         )
         scopePermissionOrNull
-    }
-
-    private fun assertScopePermissionDoesNotExist(
-        targetScopeAddress: String = scopeAddress,
-        granterAddress: String = priorityOwnerAddress,
-        granteeAddress: String = grantee.bech32Address,
-        grantId: String? = null,
-        messagePrefix: String? = null,
-    ) {
-        assertNull(
-            actual = findScopePermissionOrNull(
-                scopeAddress = targetScopeAddress,
-                granterAddress = granterAddress,
-                granteeAddress = granteeAddress,
-                grantId = grantId,
-            ),
-            message = "${messagePrefix ?: "Scope permission should not exist"}: Found scope permission with scope address [$targetScopeAddress], granter [$granterAddress], grantee [$granteeAddress], and grant ID [$grantId]",
-        )
     }
 
     private fun findScopePermissionOrNull(


### PR DESCRIPTION
# Description
This PR adds rpc routes for authorized actors to grant access to scope records and to revoke access to scope records.  These routes follow the same patterns that the gateway event processor does, and ensures that only the master key and scope owner can do grants, and that the master key, scope owner, and grantee can do revokes.

## Changes
- Include two new rpc routes, `GrantScopePermission` and `RevokeScopePermission`.
- Add new route functions to the client
- Add new route handlers into the `ObjectStoreGatewayServer` and add a TODO about better exception handling
- Add a new generic `fetchScope` to the `ScopeFetchService` that directly returns a scope to facilitate doing that in other services.
- Create a new `ScopePermissionsService` that allows the new rpc routes to invoke the same functionality that the event handler currently does.
- Add an obscene amount of tests to make sure this didn't introduce any new bugs