### PR TITLE
Feature: Data storage accounts table

### DIFF
--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/model/DataStorageAccounts.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/model/DataStorageAccounts.kt
@@ -1,0 +1,47 @@
+package tech.figure.objectstore.gateway.model
+
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.sql.and
+import tech.figure.objectstore.gateway.sql.VarcharEntity
+import tech.figure.objectstore.gateway.sql.VarcharEntityClass
+import tech.figure.objectstore.gateway.sql.VarcharTable
+import tech.figure.objectstore.gateway.sql.offsetDatetime
+import java.time.OffsetDateTime
+
+object DataStorageAccountsTable : VarcharTable(
+    name = "data_storage_accounts",
+    columnName = "account_address",
+    columnLength = 44,
+) {
+    val enabled = bool("enabled").default(true)
+    val created = offsetDatetime("created").clientDefault { OffsetDateTime.now() }
+}
+
+open class DataStorageAccountsClass : VarcharEntityClass<DataStorageAccount>(DataStorageAccountsTable) {
+    fun new(accountAddress: String, enabled: Boolean = true): DataStorageAccount =
+        findByAddressOrNull(accountAddress, enabledOnly = false) ?: new(accountAddress) { this.enabled = enabled }
+
+    fun setEnabled(accountAddress: String, enabled: Boolean): DataStorageAccount? =
+        findByAddressOrNull(accountAddress = accountAddress, enabledOnly = false)?.apply { this.enabled = enabled }
+
+    fun findByAddressOrNull(
+        accountAddress: String,
+        enabledOnly: Boolean = true,
+    ): DataStorageAccount? = find {
+        DataStorageAccountsTable.id.eq(accountAddress).let { query ->
+            if (enabledOnly) {
+                query.and { DataStorageAccountsTable.enabled.eq(true) }
+            } else {
+                query
+            }
+        }
+    }.firstOrNull()
+}
+
+class DataStorageAccount(accountAddress: EntityID<String>) : VarcharEntity(accountAddress) {
+    companion object : DataStorageAccountsClass()
+
+    val accountAddress: String by lazy { id.value }
+    var enabled: Boolean by DataStorageAccountsTable.enabled
+    val created: OffsetDateTime by DataStorageAccountsTable.created
+}

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/repository/BlockHeightRepository.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/repository/BlockHeightRepository.kt
@@ -1,11 +1,11 @@
 package tech.figure.objectstore.gateway.repository
 
 import org.jetbrains.exposed.sql.transactions.transaction
-import org.springframework.stereotype.Service
+import org.springframework.stereotype.Repository
 import tech.figure.objectstore.gateway.configuration.EventStreamProperties
 import tech.figure.objectstore.gateway.model.BlockHeight
 
-@Service
+@Repository
 class BlockHeightRepository(private val eventStreamProperties: EventStreamProperties) {
     private val blockHeightUuid = eventStreamProperties.blockHeightTrackingUuid
 

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/repository/DataStorageAccountsRepository.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/repository/DataStorageAccountsRepository.kt
@@ -1,0 +1,20 @@
+package tech.figure.objectstore.gateway.repository
+
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.springframework.stereotype.Repository
+import tech.figure.objectstore.gateway.model.DataStorageAccount
+
+@Repository
+class DataStorageAccountsRepository {
+    fun addDataStorageAccount(accountAddress: String): DataStorageAccount = transaction {
+        DataStorageAccount.new(accountAddress)
+    }
+
+    fun setStorageAccountEnabled(accountAddress: String, enabled: Boolean): DataStorageAccount = transaction {
+        DataStorageAccount.setEnabled(accountAddress = accountAddress, enabled = enabled)
+    } ?: error("No data storage account existed for address [$accountAddress]")
+
+    fun isAddressEnabled(accountAddress: String): Boolean = transaction {
+        DataStorageAccount.findByAddressOrNull(accountAddress, enabledOnly = true)
+    } != null
+}

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/repository/ObjectPermissionsRepository.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/repository/ObjectPermissionsRepository.kt
@@ -1,10 +1,10 @@
 package tech.figure.objectstore.gateway.repository
 
 import org.jetbrains.exposed.sql.transactions.transaction
-import org.springframework.stereotype.Component
+import org.springframework.stereotype.Repository
 import tech.figure.objectstore.gateway.model.ObjectPermission
 
-@Component
+@Repository
 class ObjectPermissionsRepository {
     fun addAccessPermission(objectHash: String, granteeAddress: String, objectSize: Long) {
         transaction { ObjectPermission.new(objectHash, granteeAddress, objectSize) }

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/repository/ScopePermissionsRepository.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/repository/ScopePermissionsRepository.kt
@@ -1,10 +1,10 @@
 package tech.figure.objectstore.gateway.repository
 
 import org.jetbrains.exposed.sql.transactions.transaction
-import org.springframework.stereotype.Service
+import org.springframework.stereotype.Repository
 import tech.figure.objectstore.gateway.model.ScopePermission
 
-@Service
+@Repository
 class ScopePermissionsRepository {
     fun addAccessPermission(
         scopeAddress: String,

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/sql/DateTime.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/sql/DateTime.kt
@@ -14,6 +14,7 @@ class OffsetDateTimeColumnType : ColumnType() {
     override fun valueFromDB(value: Any): Any = when (value) {
         is java.sql.Date -> OffsetDateTime.ofInstant(value.toInstant(), ZoneId.systemDefault())
         is java.sql.Timestamp -> OffsetDateTime.ofInstant(value.toInstant(), ZoneId.systemDefault())
+        is String -> OffsetDateTime.parse(value)
         else -> value
     }
 }

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/sql/Varchar.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/sql/Varchar.kt
@@ -1,0 +1,17 @@
+package tech.figure.objectstore.gateway.sql
+
+import org.jetbrains.exposed.dao.Entity
+import org.jetbrains.exposed.dao.EntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.sql.Column
+
+open class VarcharTable(name: String, columnName: String, columnLength: Int) : IdTable<String>(name) {
+    override val id: Column<EntityID<String>> = varchar(name = columnName, length = columnLength).entityId()
+    override val primaryKey by lazy { super.primaryKey ?: PrimaryKey(id) }
+}
+
+abstract class VarcharEntity(id: EntityID<String>) : Entity<String>(id)
+
+abstract class VarcharEntityClass<out E : Entity<String>>(table: IdTable<String>, entityType: Class<E>? = null) :
+    EntityClass<String, E>(table, entityType)

--- a/server/src/main/resources/db/migration/V4_0__Data_Storage_Accounts.sql
+++ b/server/src/main/resources/db/migration/V4_0__Data_Storage_Accounts.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS data_storage_accounts(
+    account_address VARCHAR(44) PRIMARY KEY,
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    created TIMESTAMPTZ NOT NULL
+);

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/repository/DataStorageAccountsRepositoryTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/repository/DataStorageAccountsRepositoryTest.kt
@@ -1,0 +1,123 @@
+package tech.figure.objectstore.gateway.repository
+
+import org.jetbrains.exposed.sql.deleteAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import tech.figure.objectstore.gateway.model.DataStorageAccount
+import tech.figure.objectstore.gateway.model.DataStorageAccountsTable
+import java.time.OffsetDateTime
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@SpringBootTest
+class DataStorageAccountsRepositoryTest {
+    lateinit var repository: DataStorageAccountsRepository
+
+    @BeforeEach
+    fun setUp() {
+        transaction { DataStorageAccountsTable.deleteAll() }
+        repository = DataStorageAccountsRepository()
+    }
+
+    @Test
+    fun `addDataStorageAccount should create data storage account record`() {
+        val beforeInsert = OffsetDateTime.now()
+        val accountAddress = "account address yolo"
+        repository.addDataStorageAccount(accountAddress)
+
+        transaction {
+            DataStorageAccount.findByAddressOrNull(accountAddress = accountAddress).also { account ->
+                assertNotNull(
+                    actual = account,
+                    message = "The account should be accessible by its address",
+                )
+                assertEquals(
+                    expected = accountAddress,
+                    actual = account.accountAddress,
+                    message = "The accountAddress value should properly return the primary key account address",
+                )
+                assertTrue(
+                    actual = account.enabled,
+                    message = "The account should be enabled by default",
+                )
+                assertFalse(
+                    actual = beforeInsert.isAfter(account.created),
+                    message = "The timestamp created before the insert [$beforeInsert] should not be after the created timestamp [${account.created}]",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `addDataStorageAccount returns existing value instead of creating a new one`() {
+        val accountAddress = "dank address"
+        val account = repository.addDataStorageAccount(accountAddress)
+        // Sleep for a millisecond to ensure that it's impossible for a new record to not have a new created timestamp
+        Thread.sleep(1)
+        val secondAccountMaybe = repository.addDataStorageAccount(accountAddress)
+        assertEquals(
+            expected = account.accountAddress,
+            actual = secondAccountMaybe.accountAddress,
+            message = "Account addresses should match",
+        )
+        assertEquals(
+            expected = account.enabled,
+            actual = secondAccountMaybe.enabled,
+            message = "Enabled values should match",
+        )
+        assertEquals(
+            expected = account.created,
+            actual = secondAccountMaybe.created,
+            message = "Created timestamps should match",
+        )
+    }
+
+    @Test
+    fun `setStorageAccountEnabled throws exception when the target account does not exist`() {
+        assertFailsWith<IllegalStateException>("An exception should be thrown when the target account does not exist") {
+            repository.setStorageAccountEnabled("someaddr", false)
+        }
+    }
+
+    @Test
+    fun `setStorageAccountEnabled successfully changes the target account enabled value`() {
+        val account = repository.addDataStorageAccount("myaccount")
+        assertTrue(
+            actual = account.enabled,
+            message = "Sanity check: Newly-created accounts should always be enabled",
+        )
+        val updatedAccount = repository.setStorageAccountEnabled(accountAddress = account.accountAddress, enabled = false)
+        assertFalse(
+            actual = updatedAccount.enabled,
+            message = "The updated account should be set to enabled = false",
+        )
+        val updatedAccountAgain = repository.setStorageAccountEnabled(accountAddress = account.accountAddress, enabled = true)
+        assertTrue(
+            actual = updatedAccountAgain.enabled,
+            message = "The updated account should be set to enabled = true",
+        )
+    }
+
+    @Test
+    fun `isAddressEnabled returns the proper value`() {
+        assertFalse(
+            actual = repository.isAddressEnabled("some fake account"),
+            message = "False should be returned when the target account does not exist",
+        )
+        val account = repository.addDataStorageAccount("accountsorwhatever")
+        assertTrue(
+            actual = repository.isAddressEnabled(account.accountAddress),
+            message = "All new accounts should be set to enabled",
+        )
+        repository.setStorageAccountEnabled(accountAddress = account.accountAddress, enabled = false)
+        assertFalse(
+            actual = repository.isAddressEnabled(account.accountAddress),
+            message = "The account should be enabled = false after changing the enabled status",
+        )
+    }
+}


### PR DESCRIPTION
# Description
This adds a new table that can store arbitrary accounts in order to bar access to the random object storage functionality.  This is the precursor PR to the rpc changes required for this functionality to be fully utilized.

## Changes
- Create a new table, `data_storage_accounts`.
- Create adapters for exposed that allow a `varchar` type to be used as a primary key.  Made sense to me that the bech32 address of the account should be the primary key.
- Change all repository classes in the app to use the `@Repository` Spring annotation.  That annotation has no function with our code except to differentiate the classes as logical repositories, because we don't use any of those magic spring tools that care about that annotation.  It's essentially an alias for `@Component`, so I figured it was a solid plan.
- Fix a bug in the `OffsetDateTime` column type handling.  It was incorrectly returning a `String` when a direct string value was sent from the DB (probably Sqlite's doing), which caused the delegated entity class to throw an exception and fail to convert the `String` to an `OffsetDateTime`.
- TEST THE STUFF