### PR TITLE
Feature: Add admin-only RPC routes for data storage account management

### DIFF
--- a/proto/src/main/proto/tech/figure/objectstore/gateway/admin/admin.proto
+++ b/proto/src/main/proto/tech/figure/objectstore/gateway/admin/admin.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package tech.figure.objectstore.gateway.admin;
+
+import "google/protobuf/timestamp.proto";
+
+service GatewayAdmin {
+  rpc PutDataStorageAccount(PutDataStorageAccountRequest) returns (PutDataStorageAccountResponse) {};
+  rpc FetchDataStorageAccount(FetchDataStorageAccountRequest) returns (FetchDataStorageAccountResponse) {};
+}
+
+// MASTER KEY ACCESS ONLY.  This route either adds a new account or updates an existing data storage account, allowing
+// access to the FetchObject and PutObject rpc routes.
+message PutDataStorageAccountRequest {
+  string address = 1; // The Provenance Blockchain bech32 address of the account that will be added (or updated) as an authorized user for using object storage routes
+  bool enabled = 2; // If true, this account will be enabled for object storage routes.  If false, the account will be barred from this functionality
+}
+
+message PutDataStorageAccountResponse {
+  DataStorageAccount account = 1; // The account created in the service by the request
+}
+
+// MASTER KEY ACCESS ONLY.  This route returns information about an existing data storage account.
+// If an account does not exist in the server for this address, a NOT_FOUND error will be emitted.
+message FetchDataStorageAccountRequest {
+  string address = 1; // The Provenance Blockchain bech32 address of the account for which to fetch a storage record
+}
+
+message FetchDataStorageAccountResponse {
+  DataStorageAccount account = 1; // Values pertaining to an existing data storage account
+}
+
+message DataStorageAccount {
+  string address = 1; // The Provenance Blockchain bech32 address of this account
+  bool enabled = 2; // If true, this account exists in the gateway service and is allowed to use object storage routes
+  google.protobuf.Timestamp created = 3; // The timestamp at which this account was created
+}

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/exception/GrpcExceptions.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/exception/GrpcExceptions.kt
@@ -5,5 +5,6 @@ import io.grpc.StatusRuntimeException
 
 class AccessDeniedException(message: String?) : StatusRuntimeException(Status.PERMISSION_DENIED.withDescription(message))
 class JwtValidationException(message: String?, cause: Throwable? = null) : StatusRuntimeException(Status.PERMISSION_DENIED.withDescription(message).withCause(cause))
+class NotFoundException(message: String?) : StatusRuntimeException(Status.NOT_FOUND.withDescription(message))
 class SignatureValidationException(message: String?) : StatusRuntimeException(Status.PERMISSION_DENIED.withDescription(message))
 class TimestampValidationException(message: String?) : StatusRuntimeException(Status.PERMISSION_DENIED.withDescription(message))

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/model/DataStorageAccounts.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/model/DataStorageAccounts.kt
@@ -1,5 +1,6 @@
 package tech.figure.objectstore.gateway.model
 
+import io.provenance.scope.util.toProtoTimestamp
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.and
 import tech.figure.objectstore.gateway.sql.VarcharEntity
@@ -7,6 +8,7 @@ import tech.figure.objectstore.gateway.sql.VarcharEntityClass
 import tech.figure.objectstore.gateway.sql.VarcharTable
 import tech.figure.objectstore.gateway.sql.offsetDatetime
 import java.time.OffsetDateTime
+import tech.figure.objectstore.gateway.admin.Admin.DataStorageAccount as ProtoDataStorageAccount
 
 object DataStorageAccountsTable : VarcharTable(
     name = "data_storage_accounts",
@@ -44,4 +46,30 @@ class DataStorageAccount(accountAddress: EntityID<String>) : VarcharEntity(accou
     val accountAddress: String by lazy { id.value }
     var enabled: Boolean by DataStorageAccountsTable.enabled
     val created: OffsetDateTime by DataStorageAccountsTable.created
+
+    fun toProto(): ProtoDataStorageAccount = ProtoDataStorageAccount.newBuilder().also { proto ->
+        proto.address = accountAddress
+        proto.enabled = enabled
+        proto.created = created.toProtoTimestamp()
+    }.build()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as DataStorageAccount
+
+        if (accountAddress != other.accountAddress) return false
+        if (enabled != other.enabled) return false
+        if (created != other.created) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = accountAddress.hashCode()
+        result = 31 * result + enabled.hashCode()
+        result = 31 * result + created.hashCode()
+        return result
+    }
 }

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/repository/DataStorageAccountsRepository.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/repository/DataStorageAccountsRepository.kt
@@ -6,9 +6,12 @@ import tech.figure.objectstore.gateway.model.DataStorageAccount
 
 @Repository
 class DataStorageAccountsRepository {
-    fun addDataStorageAccount(accountAddress: String): DataStorageAccount = transaction {
-        DataStorageAccount.new(accountAddress)
+    fun addDataStorageAccount(accountAddress: String, enabled: Boolean = true): DataStorageAccount = transaction {
+        DataStorageAccount.new(accountAddress = accountAddress, enabled = enabled)
     }
+
+    fun findDataStorageAccountOrNull(accountAddress: String, enabledOnly: Boolean = true): DataStorageAccount? =
+        transaction { DataStorageAccount.findByAddressOrNull(accountAddress = accountAddress, enabledOnly = enabledOnly) }
 
     fun setStorageAccountEnabled(accountAddress: String, enabled: Boolean): DataStorageAccount = transaction {
         DataStorageAccount.setEnabled(accountAddress = accountAddress, enabled = enabled)

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayAdminServer.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayAdminServer.kt
@@ -1,0 +1,74 @@
+package tech.figure.objectstore.gateway.server
+
+import com.google.protobuf.Message
+import io.grpc.stub.StreamObserver
+import io.provenance.scope.encryption.model.KeyRef
+import io.provenance.scope.encryption.util.getAddress
+import org.lognet.springboot.grpc.GRpcService
+import tech.figure.objectstore.gateway.address
+import tech.figure.objectstore.gateway.admin.Admin.FetchDataStorageAccountRequest
+import tech.figure.objectstore.gateway.admin.Admin.FetchDataStorageAccountResponse
+import tech.figure.objectstore.gateway.admin.Admin.PutDataStorageAccountRequest
+import tech.figure.objectstore.gateway.admin.Admin.PutDataStorageAccountResponse
+import tech.figure.objectstore.gateway.admin.GatewayAdminGrpc.GatewayAdminImplBase
+import tech.figure.objectstore.gateway.configuration.ProvenanceProperties
+import tech.figure.objectstore.gateway.exception.AccessDeniedException
+import tech.figure.objectstore.gateway.exception.NotFoundException
+import tech.figure.objectstore.gateway.repository.DataStorageAccountsRepository
+import tech.figure.objectstore.gateway.server.interceptor.JwtServerInterceptor
+
+@GRpcService(interceptors = [JwtServerInterceptor::class])
+class ObjectStoreGatewayAdminServer(
+    private val accountsRepository: DataStorageAccountsRepository,
+    private val masterKey: KeyRef,
+    private val provenanceProperties: ProvenanceProperties,
+) : GatewayAdminImplBase() {
+    override fun putDataStorageAccount(
+        request: PutDataStorageAccountRequest,
+        responseObserver: StreamObserver<PutDataStorageAccountResponse>,
+    ) {
+        if (responseObserver.isRequestNotMasterKey()) {
+            return
+        }
+        // Update if exists, create if not
+        val account = if (accountsRepository.findDataStorageAccountOrNull(request.address, enabledOnly = false) != null) {
+            accountsRepository.setStorageAccountEnabled(accountAddress = request.address, enabled = request.enabled)
+        } else {
+            accountsRepository.addDataStorageAccount(accountAddress = request.address, enabled = request.enabled)
+        }
+        responseObserver.onNext(
+            PutDataStorageAccountResponse.newBuilder().also { response ->
+                response.account = account.toProto()
+            }.build()
+        )
+        responseObserver.onCompleted()
+    }
+
+    override fun fetchDataStorageAccount(
+        request: FetchDataStorageAccountRequest,
+        responseObserver: StreamObserver<FetchDataStorageAccountResponse>,
+    ) {
+        if (responseObserver.isRequestNotMasterKey()) {
+            return
+        }
+        accountsRepository.findDataStorageAccountOrNull(accountAddress = request.address, enabledOnly = false)
+            ?.also { account ->
+                responseObserver.onNext(
+                    FetchDataStorageAccountResponse.newBuilder().also { response ->
+                        response.account = account.toProto()
+                    }.build()
+                )
+                responseObserver.onCompleted()
+            }
+            ?: run {
+                responseObserver.onError(NotFoundException("No account exists for address [${request.address}]"))
+            }
+    }
+
+    private fun <M : Message> StreamObserver<M>.isRequestNotMasterKey(): Boolean =
+        (address() != masterKey.publicKey.getAddress(mainNet = provenanceProperties.mainNet)).also { notMasterKey ->
+            if (notMasterKey) {
+                this.onError(AccessDeniedException("Only the master key may make this request"))
+            }
+        }
+}

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/helpers/MockkHelpers.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/helpers/MockkHelpers.kt
@@ -1,0 +1,29 @@
+package tech.figure.objectstore.gateway.helpers
+
+import com.google.protobuf.Message
+import io.grpc.StatusRuntimeException
+import io.grpc.stub.StreamObserver
+import io.mockk.CapturingSlot
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+
+/**
+ * Observer mocks will freak out and throw an exception when any of their standard response functions are called.
+ * This function will inline create a StreamObserver for the rpc message requested, ensuring that all its relevant
+ * functions utilized in this application are mocked out.
+ */
+inline fun <reified T : Message> mockkObserver(): StreamObserver<T> = mockk<StreamObserver<T>>().also { observer ->
+    every { observer.onNext(any()) } returns Unit
+    every { observer.onError(any()) } returns Unit
+    every { observer.onCompleted() } returns Unit
+}
+
+/**
+ * Generates a slot designed for capturing output when a StreamObserver intends to produce an error.
+ */
+inline fun <reified S : StatusRuntimeException> StreamObserver<*>.createErrorSlot(): CapturingSlot<S> = this.let { observer ->
+    slot<S>().also { exceptionSlot ->
+        every { observer.onError(capture(exceptionSlot)) } returns Unit
+    }
+}

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayAdminServerTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayAdminServerTest.kt
@@ -1,0 +1,229 @@
+package tech.figure.objectstore.gateway.server
+
+import io.grpc.Context
+import io.grpc.stub.StreamObserver
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyAll
+import io.provenance.hdwallet.ec.extensions.toJavaECPublicKey
+import io.provenance.hdwallet.wallet.Account
+import io.provenance.scope.encryption.util.getAddress
+import org.jetbrains.exposed.sql.deleteAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.boot.test.context.SpringBootTest
+import tech.figure.objectstore.gateway.admin.Admin.FetchDataStorageAccountRequest
+import tech.figure.objectstore.gateway.admin.Admin.FetchDataStorageAccountResponse
+import tech.figure.objectstore.gateway.admin.Admin.PutDataStorageAccountRequest
+import tech.figure.objectstore.gateway.admin.Admin.PutDataStorageAccountResponse
+import tech.figure.objectstore.gateway.configuration.ProvenanceProperties
+import tech.figure.objectstore.gateway.exception.AccessDeniedException
+import tech.figure.objectstore.gateway.exception.NotFoundException
+import tech.figure.objectstore.gateway.helpers.createErrorSlot
+import tech.figure.objectstore.gateway.helpers.genRandomAccount
+import tech.figure.objectstore.gateway.helpers.keyRef
+import tech.figure.objectstore.gateway.helpers.mockkObserver
+import tech.figure.objectstore.gateway.model.DataStorageAccountsTable
+import tech.figure.objectstore.gateway.repository.DataStorageAccountsRepository
+import java.security.PublicKey
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+@SpringBootTest
+class ObjectStoreGatewayAdminServerTest {
+    lateinit var accountsRepository: DataStorageAccountsRepository
+    lateinit var provenanceProperties: ProvenanceProperties
+    val masterAccount: Account = genRandomAccount()
+
+    lateinit var server: ObjectStoreGatewayAdminServer
+
+    private companion object {
+        const val DEFAULT_ACCOUNT: String = "default-account"
+    }
+
+    @BeforeEach
+    fun clearDb() {
+        transaction { DataStorageAccountsTable.deleteAll() }
+    }
+
+    fun setUp(requestorPublicKey: PublicKey = masterAccount.keyPair.publicKey.toJavaECPublicKey()) {
+        accountsRepository = DataStorageAccountsRepository()
+        provenanceProperties = mockk()
+        every { provenanceProperties.mainNet } returns false
+        Context.current()
+            .withValue(Constants.REQUESTOR_PUBLIC_KEY_CTX, requestorPublicKey)
+            .withValue(Constants.REQUESTOR_ADDRESS_CTX, requestorPublicKey.getAddress(false))
+            .attach()
+        server = ObjectStoreGatewayAdminServer(
+            accountsRepository = accountsRepository,
+            masterKey = masterAccount.keyRef,
+            provenanceProperties = provenanceProperties,
+        )
+    }
+
+    @Test
+    fun `putDataStorageAccount is rejected when the requestor is not the master key`() {
+        setUp(genRandomAccount().keyPair.publicKey.toJavaECPublicKey())
+        val observer = mockkObserver<PutDataStorageAccountResponse>()
+        val exceptionSlot = observer.createErrorSlot<AccessDeniedException>()
+        observer.putDataStorageAccount()
+        verifyAll(inverse = true) {
+            observer.onNext(any())
+            observer.onCompleted()
+        }
+        assertTrue(
+            actual = "Only the master key may make this request" in (
+                exceptionSlot.captured.message
+                    ?: fail("Message should be set on the captured exception")
+                ),
+            message = "The proper message should be included in the expected exception, but got: ${exceptionSlot.captured.message}",
+        )
+    }
+
+    @Test
+    fun `putDataStorageAccount creates an account when one does not yet exist`() {
+        setUp()
+        assertNull(
+            actual = accountsRepository.findDataStorageAccountOrNull(DEFAULT_ACCOUNT, enabledOnly = false),
+            message = "Sanity check: No account with the default address should exist before operations occur",
+        )
+        val observer = mockkObserver<PutDataStorageAccountResponse>()
+        observer.putDataStorageAccount()
+        val account = accountsRepository.findDataStorageAccountOrNull(DEFAULT_ACCOUNT)
+        assertNotNull(
+            actual = account,
+            message = "A data storage account should be created by the function",
+        )
+        assertEquals(
+            expected = account.accountAddress,
+            actual = DEFAULT_ACCOUNT,
+            message = "The default account address should be used",
+        )
+        assertTrue(
+            actual = account.enabled,
+            message = "The account should be initially set to enabled",
+        )
+        verify(inverse = true) { observer.onError(any()) }
+        verifyAll {
+            observer.onNext(PutDataStorageAccountResponse.newBuilder().setAccount(account.toProto()).build())
+            observer.onCompleted()
+        }
+    }
+
+    @Test
+    fun `putDataStorageAccount updates an existing account when it is targeted`() {
+        setUp()
+        accountsRepository.addDataStorageAccount(accountAddress = DEFAULT_ACCOUNT, enabled = true)
+        assertEquals(
+            expected = true,
+            actual = accountsRepository.findDataStorageAccountOrNull(DEFAULT_ACCOUNT, enabledOnly = false)?.enabled,
+            message = "Sanity check: The account should be in the database with an enabled value of true",
+        )
+        val observer = mockkObserver<PutDataStorageAccountResponse>()
+        observer.putDataStorageAccount(account = DEFAULT_ACCOUNT, enabled = false)
+        val account = accountsRepository.findDataStorageAccountOrNull(DEFAULT_ACCOUNT, enabledOnly = false)
+        assertNotNull(
+            actual = account,
+            message = "After an update, the target account should still exist in the database",
+        )
+        assertFalse(
+            actual = account.enabled,
+            message = "The update should have altered the enabled value from true to false",
+        )
+        verify(inverse = true) { observer.onError(any()) }
+        verifyAll {
+            observer.onNext(PutDataStorageAccountResponse.newBuilder().setAccount(account.toProto()).build())
+            observer.onCompleted()
+        }
+    }
+
+    @Test
+    fun `fetchDataStorageAccount is rejected when the requestor is not the master key`() {
+        setUp(genRandomAccount().keyPair.publicKey.toJavaECPublicKey())
+        val observer = mockkObserver<FetchDataStorageAccountResponse>()
+        val exceptionSlot = observer.createErrorSlot<AccessDeniedException>()
+        observer.fetchDataStorageAccount()
+        verifyAll(inverse = true) {
+            observer.onNext(any())
+            observer.onCompleted()
+        }
+        assertTrue(
+            actual = "Only the master key may make this request" in (
+                exceptionSlot.captured.message
+                    ?: fail("Message should be set on the captured exception")
+                ),
+            message = "The proper message should be included in the expected exception, but got: ${exceptionSlot.captured.message}",
+        )
+    }
+
+    @Test
+    fun `fetchDataStorageAccount returns a NotFoundException when no account exists for the given address`() {
+        setUp()
+        val observer = mockkObserver<FetchDataStorageAccountResponse>()
+        val exceptionSlot = observer.createErrorSlot<NotFoundException>()
+        observer.fetchDataStorageAccount()
+        verifyAll(inverse = true) {
+            observer.onNext(any())
+            observer.onCompleted()
+        }
+        assertTrue(
+            actual = "No account exists for address [$DEFAULT_ACCOUNT]" in (
+                exceptionSlot.captured.message
+                    ?: fail("Message should be set on the captured exception")
+                ),
+            message = "The proper message should be included in the expected exception, but got: ${exceptionSlot.captured.message}",
+        )
+    }
+
+    @Test
+    fun `fetchDataStorageAccount returns the account if it exists and is enabled`() {
+        doSuccessfulFetchTest(accountEnabled = true)
+    }
+
+    @Test
+    fun `fetchDataStorageAccount returns the account if it exists and is disabled`() {
+        doSuccessfulFetchTest(accountEnabled = false)
+    }
+
+    private fun doSuccessfulFetchTest(accountEnabled: Boolean) {
+        setUp()
+        val account = accountsRepository.addDataStorageAccount(DEFAULT_ACCOUNT, enabled = accountEnabled)
+        assertEquals(
+            expected = accountEnabled,
+            actual = account.enabled,
+            message = "Sanity check: The account should be ${if (accountEnabled) "enabled" else "disabled"} after creation",
+        )
+        val observer = mockkObserver<FetchDataStorageAccountResponse>()
+        observer.fetchDataStorageAccount()
+        verify(inverse = true) { observer.onError(any()) }
+        verifyAll {
+            observer.onNext(FetchDataStorageAccountResponse.newBuilder().setAccount(account.toProto()).build())
+            observer.onCompleted()
+        }
+    }
+
+    private fun StreamObserver<PutDataStorageAccountResponse>.putDataStorageAccount(
+        account: String = DEFAULT_ACCOUNT,
+        enabled: Boolean = true,
+    ) {
+        server.putDataStorageAccount(
+            request = PutDataStorageAccountRequest.newBuilder().setAddress(account).setEnabled(enabled).build(),
+            responseObserver = this,
+        )
+    }
+
+    private fun StreamObserver<FetchDataStorageAccountResponse>.fetchDataStorageAccount(
+        account: String = DEFAULT_ACCOUNT,
+    ) {
+        server.fetchDataStorageAccount(
+            request = FetchDataStorageAccountRequest.newBuilder().setAddress(account).build(),
+            responseObserver = this,
+        )
+    }
+}


### PR DESCRIPTION
# Description
Part two of data storage account access gating for fetch/put object code.  This allows master-key-only route access to two new routes that find an account if it exists, and allows upserts for the account.

## Changes
- Add a new `admin.proto` subset to the proto files to separate master-key-only routes from the standard routes.
- Add two new rpc routes to the admin routes, `PutDataStorageAccount` and `FetchDataStorageAccount`.