### PR TITLE
Documentation: Increase readme coverage of new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,27 +6,152 @@ format.
 
 ## Authentication
 Requests to this service must include a grpc metadata header named "Authorization" containing a valid, SECP256K1 signed Provenance
-jwt (containing the matching public key/address that was used to sign the jwt, must have a valid, future expiration [`exp`] claim).
+jwt (containing the matching public key ([`sub`] claim)/address ([`addr`] claim) that was used to sign the jwt, must have a valid, future expiration [`exp`] claim).
 Once the identity of the caller is determined/verified via the jwt, authorization for the requested data is performed according to the rules below
 
-## Authorization
-This service exposes one endpoint, used for fetching all records within a scope.
-In order for this data to be fetched, the following criteria must be met.
-1. The request must have a valid, non-expired signature
-2. The requester address/key must meet one of the following requirements:
-   1. Be an owner of the scope being requested (and have their private key registered with this service)
-   2. Have been requested by an owner of the scope as a verifier for asset classification purposes. Scopes that do not
-      include a party, value owner, or data access address matching one of the private keys registered with this service
-      will be ignored.
+## Route Definitions + Authorization
+This service exposes various grpc endpoints.  Each requires a valid, non-expired JWT header for an authorized Provenance 
+account with varying criteria based on the route:
 
-In order to facilitate this scope data permissioning, this service listens on the [Figure Tech Event Stream](https://github.com/FigureTechnologies/event-stream)
-for asset classification contract events, and stores a lookup of the address registered to this service to the address
-being assigned as an asset verifier. Later, when a request arrives for scope data, the above permissioning rules are
-used to approve/deny access. This service can only ever decrypt and return data for a private key that is registered with
-the service and is in the audience on the object in object store.
+### FetchObject
 
-Note that the data returned from this service is raw bytes, and will have to be interpreted in whatever data format is
+Fetches all records within a given scope. 
+
+Note that the data returned from this route is raw bytes, and will have to be interpreted in whatever data format is
 expected.
+
+The requester address/key must meet one of the following requirements:
+
+1. Be an owner of the scope being requested (and have their private key registered with this service)
+2. Have been requested by an owner of a scope to be granted access to its data via smart contract wasm event using
+   the correct [attribute format](https://github.com/FigureTechnologies/os-gateway-contract-attributes).
+3. Have been requested by an owner of a scope to be granted access to its data via the [GrantScopePermission](#GrantScopePermission) 
+   route.
+
+### PutObject
+
+The service will store the given object bytes in a [Provenance Encrypted Object Store](https://github.com/provenance-io/object-store)
+using the service's registered master key, allowing for retrieval at a later time using the [FetchObjectByHash](#FetchObjectByHash)
+route.
+
+The requester address/key must be an account that was registered by the admin-only [PutDataStorageAccount](#PutDataStorageAccount) 
+route.
+
+### FetchObjectByHash
+
+The service will fetch object bytes that were stored by the [PutObject](#PutObject) route.  
+
+Note that the data returned from this route is raw bytes, and will have to be interpreted in whatever data format is
+expected.
+
+The requester address/key must have been the account that originally stored the value with the [PutObject](#PutObject)
+route.
+
+### GrantScopePermission
+
+Manually enables a Provenance Blockchain Account to retrieve all records stored in a [Provenance Encrypted Object Store](https://github.com/provenance-io/object-store), 
+but only if one of the private keys registered with this service was used as an additional audience when the records 
+were stored.  This route creates an access grant record in the database.  This will enable the requested account to use 
+the [FetchObject](#FetchObject) route.
+
+The requester address/key must meet one of the following requirements:
+
+1. Be the master key registered with the service.
+2. Be the value owner of the scope referred to by the request.
+
+### RevokeScopePermission
+
+Manually removes one or more access grant records in the database for a target scope and Provenance Blockchain Account 
+combination.
+
+The requester address/key must meet one of the following requirements:
+
+1. Be the master key registered with the service.
+2. Be the value owner of the scope referred to by the request.
+3. Be the Provenance Blockchain Account referred to be the request (self-permission-revoke).
+
+### PutDataStorageAccount
+Enables or updates a Provenance Blockchain Account's ability to use the [PutObject](#PutObject) route.
+
+The requester address/key for this route must be the master key registered with the service.
+
+### FetchDataStorageAccount
+
+Retrieves data about a Provenance Blockchain Account's ability to use the [PutObject](#PutObject) route.
+
+The requester address/key for this route must be the master key registered with the service.
+
+## Access Grants
+One of this service's primary functions is to allow Provenance Blockchain Accounts that would not normally be able to 
+read the records stored for a scope in the [Provenance Encrypted Object Store](https://github.com/provenance-io/object-store)
+access to those records.  When grants are processed for scopes, scopes that do not include a party, value owner, or data 
+access address matching one of the private keys registered with this service will be ignored.
+
+There are two ways in which grants can be added:
+
+### Wasm Event Grants
+This service watches the event stream emitted by the Provenance Blockchain using the [Figure Tech Event Stream Library](https://github.com/FigureTechnologies/event-stream).
+When the [proper event formats](server/src/main/kotlin/tech/figure/objectstore/gateway/eventstream/GatewayEvent.kt) are
+detected, the service will automatically attempt to verify the authenticity of the event's sources.  If all values are
+properly established, an access grant for a target Provenance Blockchain Scope and Provenance Blockchain Account will
+be added to the database, enabling record fetches using the [FetchObject](#FetchObject) route.  Only events emitted by 
+transactions signed by the owner of the target scope will be regarded as valid.
+
+Properly-formed events include the following attributes:
+
+- `object_store_gateway_event_type`: This value should be set to `access_grant` to be correctly processed as a grant.
+- `object_store_gateway_target_scope_address`: This value should include the Provenance Blockchain Scope bech32 address
+of the scope for which access to records will be granted.
+- `object_store_gateway_target_account_address`: This value should include the Provenance Blockchain Account bech32
+address of the account to which record access will be granted.
+- `object_store_gateway_access_grant_id`: This value is optional and the attribute may be omitted entirely.  If included,
+this value should be a unique string that will allow targeted access revocations.  Duplicate values to the service will
+cause the event to be ignored when processed.
+
+### Manual Event Grants
+
+In addition to event stream parsing, a manual grpc request is offered to perform access grants.  See: 
+[GrantScopePermission](#GrantScopePermission).
+
+## Access Revokes
+The ability to revoke grants that were previously processed is available alongside the [Access Grants](#Access Grants)
+functionality.  This functionality will remove all access previously granted to a Provenance Blockchain Account to view
+the records associated with a Provenance Blockchain Scope.  
+
+Like the grants functionality, two methods of performing an access revoke are provided:
+
+### Wasm Event Revokes
+This service watches the event stream emitted by the Provenance Blockchain using the [Figure Tech Event Stream Library](https://github.com/FigureTechnologies/event-stream).
+When the [proper event formats](server/src/main/kotlin/tech/figure/objectstore/gateway/eventstream/GatewayEvent.kt) are
+detected, the service will automatically attempt to verify the authenticity of the event's sources.  If all values are
+properly established, any access grants for a target Provenance Blockchain Scope and Provenance Blockchain Account will
+be removed from the database, preventing future record fetches using the [FetchObject](#FetchObject) route.  Only events 
+emitted by transactions signed by the owner of the target scope or by the account for which access will be revoked will 
+be regarded as valid.
+
+Properly-formed events include the following attributes:
+
+- `object_store_gateway_event_type`: This value should be set to `access_revoke` to be correctly processed as a revoke.
+- `object_store_gateway_target_scope_address`: This value should include a Provenance Blockchain Scope bech32 address
+to which a Provenance Blockchain Account currently has record access via this service.
+- `object_store_gateway_target_account_address`: This value should include a Provenance Blockchain Account bech32 
+address for which to revoke access.
+- `object_store_gateway_access_grant_id`: This value is optional and the attribute may be omitted entirely.  If included,
+this value should be a unique string that was used when an access grant was created.  If the grant id is specified as
+an id unrelated to any existing grants, no grants will be deleted upon the successful processing of a revoke request. If
+this value is omitted, all grants with the scope and target account values will be removed upon processing.
+
+### Manual Event Revokes
+
+In addition to event stream parsing, a manual request is offered to perform access revokes.  See:
+[RevokeScopePermission](#RevokeScopePermission).
+
+## Object Store Gateway Contract Attributes Rust Library
+To facilitate the grant/revoke event structure in a [CosmWasm](https://github.com/CosmWasm/cosmwasm)-based smart 
+contract, the following Rust library is available: [os-gateway-contract-attributes](https://github.com/FigureTechnologies/os-gateway-contract-attributes).
+
+It provides a helper struct for creating the entire event structure, properly grouped.  It also exposes the individual
+keys and expected event type values as constants to allow custom implementations if desired.
 
 ## Client
 There is a client library provided to help facilitate making requests to this service. This can be used to construct a

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ REQUIRED | Boolean
 If this value is true, the server will automatically start watching events from the target Provenance Blockchain event
 URI.  If not, a warning message will be emitted and the application will only be available for RPC route utilization.
 
-### EVENT_STREAM_BLOCK_HEIGHT_TRACKING_UUID`
+### EVENT_STREAM_BLOCK_HEIGHT_TRACKING_UUID
 REQUIRED | UUID v4
 
 A UUID that establishes the latest block height.  If the app needs to re-run various events, swap this value to a new

--- a/README.md
+++ b/README.md
@@ -9,6 +9,26 @@ Requests to this service must include a grpc metadata header named "Authorizatio
 jwt (containing the matching public key ([`sub`] claim)/address ([`addr`] claim) that was used to sign the jwt, must have a valid, future expiration [`exp`] claim).
 Once the identity of the caller is determined/verified via the jwt, authorization for the requested data is performed according to the rules below
 
+## Client
+There is a client library provided to help facilitate making requests to this service. This can be used to construct a
+jwt for requests to facilitate authentication if you do not already have another means of generating a jwt.
+
+Example of creating a client:
+
+```kotlin
+import java.net.URI
+import tech.figure.objectstore.gateway.client.ClientConfig
+import tech.figure.objectstore.gateway.client.GatewayClient
+
+fun getClient(): GatewayClient = GatewayClient(
+    config = ClientConfig(
+        gatewayUri = URI.create("grpcs://my.org"),
+        mainNet = true,
+        // See ClientConfig for descriptions of each optional parameter
+    ),
+)
+```
+
 ## Route Definitions + Authorization
 This service exposes various grpc endpoints.  Each requires a valid, non-expired JWT header for an authorized Provenance 
 account with varying criteria based on the route:
@@ -81,7 +101,9 @@ Retrieves data about a Provenance Blockchain Account's ability to use the [PutOb
 
 The requester address/key for this route must be the master key registered with the service.
 
-## Access Grants
+## Core Functionality
+
+### Access Grants
 One of this service's primary functions is to allow Provenance Blockchain Accounts that would not normally be able to 
 read the records stored for a scope in the [Provenance Encrypted Object Store](https://github.com/provenance-io/object-store)
 access to those records.  When grants are processed for scopes, scopes that do not include a party, value owner, or data 
@@ -89,7 +111,7 @@ access address matching one of the private keys registered with this service wil
 
 There are two ways in which grants can be added:
 
-### Wasm Event Grants
+#### Wasm Event Grants
 This service watches the event stream emitted by the Provenance Blockchain using the [Figure Tech Event Stream Library](https://github.com/FigureTechnologies/event-stream).
 When the [proper event formats](server/src/main/kotlin/tech/figure/objectstore/gateway/eventstream/GatewayEvent.kt) are
 detected, the service will automatically attempt to verify the authenticity of the event's sources.  If all values are
@@ -108,19 +130,19 @@ address of the account to which record access will be granted.
 this value should be a unique string that will allow targeted access revocations.  Duplicate values to the service will
 cause the event to be ignored when processed.
 
-### Manual Event Grants
+#### Manual Event Grants
 
 In addition to event stream parsing, a manual grpc request is offered to perform access grants.  See: 
 [GrantScopePermission](#GrantScopePermission).
 
-## Access Revokes
+### Access Revokes
 The ability to revoke grants that were previously processed is available alongside the [Access Grants](#Access Grants)
 functionality.  This functionality will remove all access previously granted to a Provenance Blockchain Account to view
 the records associated with a Provenance Blockchain Scope.  
 
 Like the grants functionality, two methods of performing an access revoke are provided:
 
-### Wasm Event Revokes
+#### Wasm Event Revokes
 This service watches the event stream emitted by the Provenance Blockchain using the [Figure Tech Event Stream Library](https://github.com/FigureTechnologies/event-stream).
 When the [proper event formats](server/src/main/kotlin/tech/figure/objectstore/gateway/eventstream/GatewayEvent.kt) are
 detected, the service will automatically attempt to verify the authenticity of the event's sources.  If all values are
@@ -141,18 +163,148 @@ this value should be a unique string that was used when an access grant was crea
 an id unrelated to any existing grants, no grants will be deleted upon the successful processing of a revoke request. If
 this value is omitted, all grants with the scope and target account values will be removed upon processing.
 
-### Manual Event Revokes
+#### Manual Event Revokes
 
 In addition to event stream parsing, a manual request is offered to perform access revokes.  See:
 [RevokeScopePermission](#RevokeScopePermission).
 
-## Object Store Gateway Contract Attributes Rust Library
-To facilitate the grant/revoke event structure in a [CosmWasm](https://github.com/CosmWasm/cosmwasm)-based smart 
+### Object Storage
+The service's other primary functionality is to provide object storage for enabled third party Provenance Blockchain
+Account addresses.  The GRPC routes provided, [PutObject](#PutObject) and [FetchObject](#FetchObject) allow for accounts
+authorized by the admin [PutDataStorageAccount](#PutDataStorageAccount) route to store arbitrary objects of any sort
+in the service's configured [Provenance Encrypted Object Store](https://github.com/provenance-io/object-store) instance.
+These objects are wrapped in proto that encodes additional metadata, hashed using sha256, and stored using the service's
+configured [OBJECTSTORE_MASTER_KEY](#OBJECTSTORE_MASTER_KEY).
+
+## Contract Attributes Rust Library
+To facilitate the grant/revoke event structure in a [CosmWasm](https://github.com/CosmWasm/cosmwasm)-based smart
 contract, the following Rust library is available: [os-gateway-contract-attributes](https://github.com/FigureTechnologies/os-gateway-contract-attributes).
 
 It provides a helper struct for creating the entire event structure, properly grouped.  It also exposes the individual
 keys and expected event type values as constants to allow custom implementations if desired.
 
-## Client
-There is a client library provided to help facilitate making requests to this service. This can be used to construct a
-jwt for requests to facilitate authentication if you do not already have another means of generating a jwt.
+## Server Configuration
+
+When deployed as a [Docker](https://www.docker.com/) Container, the application utilizes various environment variables
+to customize its functionality.  The deployment properties file is located [here](server/src/main/resources/application-container.properties).
+
+The following environment variables are accepted as input:
+
+### EVENT_STREAM_WEBSOCKET_URI
+REQUIRED | String
+
+An HTTP address to use in order to establish a connection to a trusted Provenance Blockchain Query Node for watching
+events emitted by the relevant Provenance Blockchain network.
+
+### EVENT_STREAM_EPOCH_HEIGHT
+REQUIRED | String
+
+The service dynamically tracks each encountered block from the Provenance Blockchain in its `block_height` table.  This
+value will cause the event processor to start processing blocks at this height if no value has ever been stored in the
+table.
+
+### EVENT_STREAM_ENABLED
+REQUIRED | Boolean
+
+If this value is true, the server will automatically start watching events from the target Provenance Blockchain event
+URI.  If not, a warning message will be emitted and the application will only be available for RPC route utilization.
+
+### EVENT_STREAM_BLOCK_HEIGHT_TRACKING_UUID`
+REQUIRED | UUID v4
+
+A UUID that establishes the latest block height.  If the app needs to re-run various events, swap this value to a new
+UUID to force the application to use a new value for [EVENT_STREAM_EPOCH_HEIGHT](#EVENT_STREAM_EPOCH_HEIGHT).
+
+### OBJECTSTORE_URI
+REQUIRED | String
+
+A grpc URI to use to establish a connection to an existing instance of a [Provenance Encrypted Object Store](https://github.com/provenance-io/object-store).
+This should be an Object Store instance that is used by other applications in an organizations environment that create
+Provenance Blockchain Scopes and store their records using one or more of the addresses stored in the
+[OBJECTSTORE_PRIVATE_KEYS](#OBJECTSTORE_PRIVATE_KEYS) variable as an additional audience.
+
+### OBJECTSTORE_PRIVATE_KEYS
+REQUIRED | CSV (Strings)
+
+A CSV list of hex-encoded Private Keys that belong to the Provenance Blockchain Accounts that have been/will be used as
+additional audiences when encoding Provenance Blockchain Scope Records to the [Provenance Encrypted Object Store](https://github.com/provenance-io/object-store)
+instance referred to by [OBJECTSTORE_URI](#OBJECTSTORE_URI).
+
+### OBJECTSTORE_MASTER_KEY
+REQUIRED | String
+
+A hex-encoded PrivateKey that belongs to a Provenance Blockchain Account that should be held by an administrator of the
+Object Store Gateway instance.  This value is uniquely given access to create and manage data access accounts, as well
+as being able to manually add and revoke scope access grants.  Due to this, it is vital that the holder of this key be
+a trusted entity in an organization.
+
+### PROVENANCE_MAIN_NET
+REQUIRED | Boolean
+
+Denotes to the application how to derive bech32 addresses during its execution.  Provenance Blockchain Account bech32
+addresses use different prefixes and HD paths based on the environment (mainnet/testnet).
+
+### PROVENANCE_CHAIN_ID
+REQUIRED | String
+
+An identifier designating which Provenance Blockchain instance that the application executes queries against.  This,
+in tandem with [PROVENANCE_CHANNEL_URI](#PROVENANCE_CHANNEL_URI), ensures that values from a trust Provenance Blockchain
+instance are used.
+
+### PROVENANCE_CHANNEL_URI
+REQUIRED | String
+
+A grpc URI that denotes which Provenance Blockchain node the service's [PbClient](https://github.com/provenance-io/pb-grpc-client-kotlin)
+communicates with.
+
+### DB_TYPE
+REQUIRED | One of: postgresql, memory, sqlite
+
+Configures the type of database instance with which the service will communicate.  The following values mandate the
+following requirements:
+
+- `postgresql`: A PostgreSQL database named with the value used by [DB_NAME](#DB_NAME) needs to be created before starting
+  the application.
+- `sqlite`: A Sqlite file must either exist at the location established by [DB_HOST](#DB_HOST) and [DB_NAME](#DB_NAME),
+  or one will be created automatically.
+- `memory`: No requirements are needed for this configuration.  The caveat is that all data established by the
+  application will be lost if it is shutdown or restarted.
+
+### DB_NAME
+REQUIRED | String
+
+The name qualifier for the database to be used.  This value's content is irrelevant if the `memory` [DB_TYPE](#DB_TYPE)
+value is used.
+
+### DB_USERNAME
+REQUIRED | String
+
+The username that will be used to log into the target database instance.  This value's content is irrelevant if the
+`sqlite` or `memory` [DB_TYPE](#DB_TYPE) values are used.
+
+### DB_PASSWORD
+REQUIRED | String
+
+The password that will be used to log into the target database instance.  This value's content is irrelevant if the
+`sqlite` or `memory` [DB_TYPE](#DB_TYPE) values are used.
+
+### DB_HOST
+REQUIRED | String
+
+The server location of the database.  This value's content is irrelevant if the `memory` [DB_TYPE](#DB_TYPE) is used.
+
+### DB_PORT
+REQUIRED | Integer
+
+The server connection port of the database.  This value's content is irrelevant if the `sqlite` or `memory` [DB_TYPE](#DB_TYPE)
+values are used.
+
+### DB_SCHEMA
+REQUIRED | String
+
+The schema name under which tables are established in the target database.
+
+### DB_CONNECTION_POOL_SIZE
+REQUIRED | Integer
+
+The maximum amount of connections that will be simultaneously used with the target database.

--- a/client/src/main/kotlin/tech/figure/objectstore/gateway/client/ClientConfig.kt
+++ b/client/src/main/kotlin/tech/figure/objectstore/gateway/client/ClientConfig.kt
@@ -6,6 +6,18 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
+/**
+ * Configuration values for a GatewayClient.
+ *
+ * @param gatewayUri A grpc URI for communication with a deployed object-store-gateway server.  Ex: grpcs://my.org
+ * @param mainNet If true, the client will generate JWT values using the Provenance Blockchain mainnet human-readable-
+ * prefix: pb.  Otherwise, the testnet hrp will be used: tp.
+ * @param channelConfigLambda Allows for dynamic configuration of a NettyChannelBuilder used to create the grpc stubs
+ * used in the GatewayClient after all other parameters are supplied as input.
+ *
+ * The remaining parameters are directly passed into a NettyChannelBuilder.  The documentation for the builder can be
+ * found at: https://www.javadoc.io/doc/io.grpc/grpc-all/1.45.1/io/grpc/netty/NettyChannelBuilder.html
+ */
 data class ClientConfig(
     val gatewayUri: URI,
     val mainNet: Boolean,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 bouncyCastle = "1.70"
 exposed = "0.37.3"
 flyway = "8.0.2"
-grpc = "1.45.1"
+grpc = "1.45.1" # If updating this value, ensure to update the doc reference in the ClientConfig class
 grpcSpringboot = "3.4.3"
 hikariCP = "5.0.1"
 jackson = "2.12.5"

--- a/proto/src/main/proto/tech/figure/objectstore/gateway/gateway.proto
+++ b/proto/src/main/proto/tech/figure/objectstore/gateway/gateway.proto
@@ -15,7 +15,6 @@ message FetchObjectRequest {
   string granter_address = 2; // optional
 }
 
-
 message FetchObjectResponse {
   string scope_id = 1;
   repeated Record records = 2;

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/components/EventStreamConsumer.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/components/EventStreamConsumer.kt
@@ -41,6 +41,10 @@ class EventStreamConsumer(
     private val decoderAdapter = moshiDecoderAdapter()
 
     override fun onApplicationEvent(event: ApplicationReadyEvent) {
+        if (!eventStreamProperties.enabled) {
+            logger.warn("Event stream has been manually disabled! Use a value of `true` for EVENT_STREAM_ENABLED to re-enable it")
+            return
+        }
         tryStartEventStream {
             eventStreamLoop()
         }

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/AppProperties.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/AppProperties.kt
@@ -12,7 +12,6 @@ import java.util.UUID
 @Validated
 data class EventStreamProperties(
     val websocketUri: URI,
-    val rpcUri: URI,
     val epochHeight: Long,
     val enabled: Boolean,
     val blockHeightTrackingUuid: UUID,

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/DataConfig.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/DataConfig.kt
@@ -42,6 +42,7 @@ class DataConfig {
                     jdbcUrl = "jdbc:sqlite:${databaseProperties.host.trimEnd('/')}/${databaseProperties.name}.db"
                     TransactionManager.manager.defaultIsolationLevel = Connection.TRANSACTION_SERIALIZABLE
                 }
+                else -> throw IllegalArgumentException("Only the values [postgresql, memory, sqlite] are allowed for DB_TYPE")
             }
             logger.info("Connecting to {} on schema {} with user {}", jdbcUrl, databaseProperties.schema, databaseProperties.username)
             username = databaseProperties.username

--- a/server/src/main/resources/application-container.properties
+++ b/server/src/main/resources/application-container.properties
@@ -1,6 +1,5 @@
 # Event Stream Configuration
 event.stream.websocket_uri=${EVENT_STREAM_WEBSOCKET_URI}
-event.stream.rpc_uri=${EVENT_STREAM_RPC_URI}
 event.stream.epoch_height=${EVENT_STREAM_EPOCH_HEIGHT}
 event.stream.enabled=${EVENT_STREAM_ENABLED}
 event.stream.blockHeightTrackingUuid=${EVENT_STREAM_BLOCK_HEIGHT_TRACKING_UUID}

--- a/server/src/main/resources/application-development.properties
+++ b/server/src/main/resources/application-development.properties
@@ -1,6 +1,5 @@
 # Event Stream Configuration
 event.stream.websocket_uri=ws://localhost:26657
-event.stream.rpc_uri=http://localhost:26657
 event.stream.epoch_height=1
 event.stream.enabled=true
 event.stream.blockHeightTrackingUuid=0F075A78-867C-4E57-BB12-F70D89B3CA0E

--- a/server/src/main/resources/application-testnet_local.properties
+++ b/server/src/main/resources/application-testnet_local.properties
@@ -1,6 +1,5 @@
 # Event Stream Configuration
 event.stream.websocket_uri=ws://rpc-0.test.provenance.io:26657
-event.stream.rpc_uri=http://rpc-0.test.provenance.io:26657
 event.stream.epoch_height=7000000
 event.stream.enabled=true
 event.stream.blockHeightTrackingUuid=0F075A78-867C-4E57-BB12-F70D89B3CA0E


### PR DESCRIPTION
# Description
This PR primarily just revamps the readme with additional/altered information based on the changes made for the v3.0.0 release.  

## Changes
- Alter readme to cover server configuration and all newly-available grpc routes.
- Remove the `EVENT_STREAM_RPC_URI` environment variable and its associated properties because they were not used.
- Add code to enable the `EVENT_STREAM_ENABLED` environment variable to take effect on the application.
- Fail fast when an unexpected `DB_TYPE` value is provided