### PR TITLE
Bugfix: contract and server event string mismatch

### DIFF
--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/eventstream/GatewayExpectedAttribute.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/eventstream/GatewayExpectedAttribute.kt
@@ -22,7 +22,7 @@ enum class GatewayExpectedAttribute(val key: String) {
      * The bech32 Provenance Blockchain scope address to which the event is related.  This will cause the gateway to
      * look up the target scope and verify its contents based on the event type.
      */
-    SCOPE_ADDRESS("object_store_gateway_target_scope_address"),
+    SCOPE_ADDRESS("object_store_gateway_scope_address"),
 
     /**
      * The bech32 address of the account for which to execute the event actions.


### PR DESCRIPTION
# Description
Just an oopsie.  The values declared in the server were almost the same as those in os-gateway-contract-attributes, but not quite.  Removing the `target_` from this key makes all values match.