### PR TITLE
Bugfix: Master key overwrites private keys

### DIFF
--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/BeanQualifiers.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/BeanQualifiers.kt
@@ -2,4 +2,7 @@ package tech.figure.objectstore.gateway.configuration
 
 object BeanQualifiers {
     const val EVENT_STREAM_COROUTINE_SCOPE_QUALIFIER = "eventStreamCoroutineScopeBean"
+    const val OBJECTSTORE_ENCRYPTION_KEYS: String = "objectStoreEncryptionKeys"
+    const val OBJECTSTORE_PRIVATE_KEYS: String = "objectStorePrivateKeys"
+    const val OBJECTSTORE_MASTER_KEY: String = "objectStoreMasterKey"
 }

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayAdminServer.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayAdminServer.kt
@@ -8,12 +8,14 @@ import io.provenance.scope.encryption.model.KeyRef
 import io.provenance.scope.encryption.util.getAddress
 import mu.KLogging
 import org.lognet.springboot.grpc.GRpcService
+import org.springframework.beans.factory.annotation.Qualifier
 import tech.figure.objectstore.gateway.address
 import tech.figure.objectstore.gateway.admin.Admin.FetchDataStorageAccountRequest
 import tech.figure.objectstore.gateway.admin.Admin.FetchDataStorageAccountResponse
 import tech.figure.objectstore.gateway.admin.Admin.PutDataStorageAccountRequest
 import tech.figure.objectstore.gateway.admin.Admin.PutDataStorageAccountResponse
 import tech.figure.objectstore.gateway.admin.GatewayAdminGrpc.GatewayAdminImplBase
+import tech.figure.objectstore.gateway.configuration.BeanQualifiers
 import tech.figure.objectstore.gateway.configuration.ProvenanceProperties
 import tech.figure.objectstore.gateway.exception.AccessDeniedException
 import tech.figure.objectstore.gateway.exception.NotFoundException
@@ -23,7 +25,7 @@ import tech.figure.objectstore.gateway.server.interceptor.JwtServerInterceptor
 @GRpcService(interceptors = [JwtServerInterceptor::class])
 class ObjectStoreGatewayAdminServer(
     private val accountsRepository: DataStorageAccountsRepository,
-    private val masterKey: KeyRef,
+    @Qualifier(BeanQualifiers.OBJECTSTORE_MASTER_KEY) private val masterKey: KeyRef,
     private val provenanceProperties: ProvenanceProperties,
 ) : GatewayAdminImplBase() {
     private companion object : KLogging()

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServer.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServer.kt
@@ -7,11 +7,13 @@ import io.provenance.scope.encryption.model.KeyRef
 import io.provenance.scope.encryption.util.getAddress
 import mu.KLogging
 import org.lognet.springboot.grpc.GRpcService
+import org.springframework.beans.factory.annotation.Qualifier
 import tech.figure.objectstore.gateway.GatewayGrpc
 import tech.figure.objectstore.gateway.GatewayOuterClass
 import tech.figure.objectstore.gateway.GatewayOuterClass.GrantScopePermissionResponse
 import tech.figure.objectstore.gateway.GatewayOuterClass.RevokeScopePermissionResponse
 import tech.figure.objectstore.gateway.address
+import tech.figure.objectstore.gateway.configuration.BeanQualifiers
 import tech.figure.objectstore.gateway.configuration.ProvenanceProperties
 import tech.figure.objectstore.gateway.publicKey
 import tech.figure.objectstore.gateway.server.interceptor.JwtServerInterceptor
@@ -23,7 +25,7 @@ import tech.figure.objectstore.gateway.service.ScopePermissionsService
 
 @GRpcService(interceptors = [JwtServerInterceptor::class])
 class ObjectStoreGatewayServer(
-    private val masterKey: KeyRef,
+    @Qualifier(BeanQualifiers.OBJECTSTORE_MASTER_KEY) private val masterKey: KeyRef,
     private val scopeFetchService: ScopeFetchService,
     private val scopePermissionsService: ScopePermissionsService,
     private val objectService: ObjectService,

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/service/ObjectService.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/service/ObjectService.kt
@@ -7,8 +7,10 @@ import io.provenance.scope.objectstore.util.base64Decode
 import io.provenance.scope.objectstore.util.toHex
 import io.provenance.scope.util.NotFoundException
 import io.provenance.scope.util.base64String
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import tech.figure.objectstore.gateway.GatewayOuterClass
+import tech.figure.objectstore.gateway.configuration.BeanQualifiers
 import tech.figure.objectstore.gateway.configuration.ProvenanceProperties
 import tech.figure.objectstore.gateway.exception.AccessDeniedException
 import tech.figure.objectstore.gateway.repository.DataStorageAccountsRepository
@@ -20,7 +22,7 @@ import java.security.PublicKey
 class ObjectService(
     private val accountsRepository: DataStorageAccountsRepository,
     private val objectStoreClient: CachedOsClient,
-    private val masterKey: KeyRef,
+    @Qualifier(BeanQualifiers.OBJECTSTORE_MASTER_KEY) private val masterKey: KeyRef,
     private val objectPermissionsRepository: ObjectPermissionsRepository,
     private val provenanceProperties: ProvenanceProperties,
 ) {

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/service/ScopeFetchService.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/service/ScopeFetchService.kt
@@ -9,8 +9,10 @@ import io.provenance.scope.objectstore.client.CachedOsClient
 import io.provenance.scope.objectstore.util.base64Decode
 import io.provenance.scope.sdk.extensions.resultType
 import mu.KLogging
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import tech.figure.objectstore.gateway.GatewayOuterClass
+import tech.figure.objectstore.gateway.configuration.BeanQualifiers
 import tech.figure.objectstore.gateway.configuration.ProvenanceProperties
 import tech.figure.objectstore.gateway.exception.AccessDeniedException
 import tech.figure.objectstore.gateway.repository.ScopePermissionsRepository
@@ -23,7 +25,7 @@ class ScopeFetchService(
     private val objectStoreClient: CachedOsClient,
     private val pbClient: PbClient,
     private val scopePermissionsRepository: ScopePermissionsRepository,
-    private val encryptionKeys: Map<String, KeyRef>,
+    @Qualifier(BeanQualifiers.OBJECTSTORE_ENCRYPTION_KEYS) private val encryptionKeys: Map<String, KeyRef>,
     private val provenanceProperties: ProvenanceProperties,
 ) {
     companion object : KLogging()

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/service/ScopePermissionsService.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/service/ScopePermissionsService.kt
@@ -2,12 +2,14 @@ package tech.figure.objectstore.gateway.service
 
 import io.provenance.metadata.v1.ScopeResponse
 import mu.KLogging
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
+import tech.figure.objectstore.gateway.configuration.BeanQualifiers
 import tech.figure.objectstore.gateway.repository.ScopePermissionsRepository
 
 @Service
 class ScopePermissionsService(
-    private val accountAddresses: Set<String>,
+    @Qualifier(BeanQualifiers.OBJECTSTORE_PRIVATE_KEYS) private val accountAddresses: Set<String>,
     private val scopeFetchService: ScopeFetchService,
     private val scopePermissionsRepository: ScopePermissionsRepository,
 ) {


### PR DESCRIPTION
# Description
This fixes a bug that prevents any events from being parsed.  Right now, the app assumes that the `encryptionKeys` is just a set of a single value, `"masterKey"`.

Without bean qualifiers, the inclusion of the `masterKey` bean that's just a plain `KeyRef` somehow causes Spring to set the private keys to a one-element `Set<String>` containing just the value `masterKey`.  I believe Spring may be creating some odd placeholder Bean when doing dependency resolution for the `encryptionKeys` value input to the `accountAddresses` function in `AppConfig`, which ends up being a map of the `masterKey` value with its function name as the key.

Regardless, swapping to explicit qualifiers for key injection solves the problem and allows events to be properly parsed.