### PR TITLE
Bugfix: Flyway migration on existing db override value

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,3 +308,10 @@ The schema name under which tables are established in the target database.
 REQUIRED | Integer
 
 The maximum amount of connections that will be simultaneously used with the target database.
+
+### DB_BASELINE_ON_MIGRATE
+OPTIONAL | Boolean | Default = false
+
+The value used for Flyway's baselineOnMigrate functionality.  This value determines if flyway should run migrations from
+its baseline version on an existing database.  See the [Flyway documentation](https://flywaydb.org/documentation/configuration/parameters/baselineOnMigrate)
+on this value for more information.

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/AppProperties.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/AppProperties.kt
@@ -52,4 +52,5 @@ data class DatabaseProperties(
     val port: String,
     val schema: String,
     @Pattern(value = "\\d{1,2}") val connectionPoolSize: String,
+    val baselineOnMigrate: Boolean,
 )

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/DataConfig.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/DataConfig.kt
@@ -74,7 +74,7 @@ class DataConfig {
 
     @Bean
     fun flyway(dataSource: DataSource, databaseProperties: DatabaseProperties): Flyway = Flyway(
-        FluentConfiguration().dataSource(dataSource).apply {
+        FluentConfiguration().dataSource(dataSource).baselineOnMigrate(databaseProperties.baselineOnMigrate).apply {
             if (databaseProperties.type != "postgresql") {
                 // skip initial 1_0__Init_UUID migration for non-postgres dbs as this isn't supported for sqlite/memory
                 baselineVersion("1.0")

--- a/server/src/main/resources/application-container.properties
+++ b/server/src/main/resources/application-container.properties
@@ -23,3 +23,4 @@ db.host=${DB_HOST}
 db.port=${DB_PORT}
 db.schema=${DB_SCHEMA}
 db.connectionPoolSize=${DB_CONNECTION_POOL_SIZE}
+db.baselineOnMigrate=${DB_BASELINE_ON_MIGRATE:false}

--- a/server/src/main/resources/application-development.properties
+++ b/server/src/main/resources/application-development.properties
@@ -23,3 +23,4 @@ db.host=memory
 db.port=""
 db.schema=object-store-gateway
 db.connectionPoolSize=1
+db.baselineOnMigrate=false

--- a/server/src/main/resources/application-testnet_local.properties
+++ b/server/src/main/resources/application-testnet_local.properties
@@ -23,3 +23,4 @@ db.host=memory
 db.port=""
 db.schema=object-store-gateway
 db.connectionPoolSize=1
+db.baselineOnMigrate=false

--- a/server/src/test/resources/application.properties
+++ b/server/src/test/resources/application.properties
@@ -24,3 +24,4 @@ db.host=memory
 db.port=""
 db.schema=object-store-gateway
 db.connectionPoolSize=1
+db.baselineOnMigrate=true


### PR DESCRIPTION
# Description
Overwriting existing deployments with the old database structure doesn't play nice out-of-the-box with Flyway.  This PR should include the ability to enable `baselineOnMigrate` for the Flyway configs, allowing the migrations to proceed.  This defaults to false because people creating a new instance should not encounter this issue.  I put this as `true` in the tests to ensure it doesn't cause any problems when enabled on fresh instances; the documentation recommends that it is left off unless needed, hence the optional value.