### PR TITLE
Testing: Verify database types can all migrate correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,3 +315,10 @@ OPTIONAL | Boolean | Default = false
 The value used for Flyway's baselineOnMigrate functionality.  This value determines if flyway should run migrations from
 its baseline version on an existing database.  See the [Flyway documentation](https://flywaydb.org/documentation/configuration/parameters/baselineOnMigrate)
 on this value for more information.
+
+### DB_REPAIR_FLYWAY_CHECKSUMS
+OPTIONAL | Boolean | Default = false
+
+This value will cause the Flyway repair functionality to be run before migrations occur.  This is an admin-only 
+functionality that is only needed if previous migration files needed to be edited after they have already been run for 
+an existing database instance.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ provenanceProto = "1.8.0-rc10"
 provenanceScope = "0.4.9"
 scarlet = "0.1.12"
 sqLite = "3.36.0.3"
+testContainers = "1.17.3"
 
 [libraries]
 bcProv = { module = "org.bouncycastle:bcprov-jdk15on", version.ref = "bouncyCastle" }
@@ -73,6 +74,8 @@ kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotli
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 starterTest = { module = "org.springframework.boot:spring-boot-starter-test" }
 javaJwt = { module = "com.auth0:java-jwt", version.ref = "jwt" }
+testContainers = { module = "org.testcontainers:testcontainers", version.ref = "testContainers" }
+testContainersPostgres = { module = "org.testcontainers:postgresql", version.ref = "testContainers" }
 
 [bundles]
 bouncyCastle = ["bcProv"]
@@ -89,3 +92,4 @@ exposed = ["exposedCore", "exposedDao", "exposedJdbc", "postgres", "hikariCP", "
 testKotlin = ["kotlinTest", "mockk"]
 testSpringBoot = ["starterTest"]
 jwt = ["javaJwt"]
+testContainers = ["testContainers", "testContainersPostgres"]

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -48,7 +48,8 @@ dependencies {
 
     listOf(
         libs.bundles.testKotlin,
-        libs.bundles.testSpringBoot
+        libs.bundles.testSpringBoot,
+        libs.bundles.testContainers,
     ).forEach(::testImplementation)
 }
 

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/AppProperties.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/AppProperties.kt
@@ -52,5 +52,6 @@ data class DatabaseProperties(
     val port: String,
     val schema: String,
     @Pattern(value = "\\d{1,2}") val connectionPoolSize: String,
-    val baselineOnMigrate: Boolean,
+    val baselineOnMigrate: Boolean = false,
+    val repairFlywayChecksums: Boolean = false,
 )

--- a/server/src/main/resources/application-container.properties
+++ b/server/src/main/resources/application-container.properties
@@ -24,3 +24,4 @@ db.port=${DB_PORT}
 db.schema=${DB_SCHEMA}
 db.connectionPoolSize=${DB_CONNECTION_POOL_SIZE}
 db.baselineOnMigrate=${DB_BASELINE_ON_MIGRATE:false}
+db.repairFlywayChecksums=${DB_REPAIR_FLYWAY_CHECKSUMS:false}

--- a/server/src/main/resources/application-development.properties
+++ b/server/src/main/resources/application-development.properties
@@ -24,3 +24,4 @@ db.port=""
 db.schema=object-store-gateway
 db.connectionPoolSize=1
 db.baselineOnMigrate=false
+db.repairFlywayChecksums=false

--- a/server/src/main/resources/application-testnet_local.properties
+++ b/server/src/main/resources/application-testnet_local.properties
@@ -24,3 +24,4 @@ db.port=""
 db.schema=object-store-gateway
 db.connectionPoolSize=1
 db.baselineOnMigrate=false
+db.repairFlywayChecksums=false

--- a/server/src/main/resources/db/migration/postgresql/V3_0__Remove_Scope_Permissions_Unique_Index.sql
+++ b/server/src/main/resources/db/migration/postgresql/V3_0__Remove_Scope_Permissions_Unique_Index.sql
@@ -1,3 +1,3 @@
 -- Remove old index that enforces unique on scope_address/grantee_address/granter_address in preparation for new index
 -- in the v3_1 migration.
-ALTER TABLE scope_permissions DROP CONSTRAINT scope_permissions_scope_address_grantee_address_granter_address;
+ALTER TABLE scope_permissions DROP CONSTRAINT IF EXISTS scope_permissions_scope_address_grantee_address_granter_address;

--- a/server/src/main/resources/db/migration/postgresql/V3_0__Remove_Scope_Permissions_Unique_Index.sql
+++ b/server/src/main/resources/db/migration/postgresql/V3_0__Remove_Scope_Permissions_Unique_Index.sql
@@ -1,3 +1,6 @@
+-- The original index from V1_1 may have been established as a constraint.  This will ensure the constraint is removed
+-- before attempting to drop the index.
+ALTER TABLE scope_permissions DROP CONSTRAINT IF EXISTS scope_permissions_scope_address_grantee_address_granter_address;
 -- Remove old index that enforces unique on scope_address/grantee_address/granter_address in preparation for new index
 -- in the v3_1 migration.
-ALTER TABLE scope_permissions DROP CONSTRAINT IF EXISTS scope_permissions_scope_address_grantee_address_granter_address;
+DROP INDEX IF EXISTS scope_permissions_scope_address_grantee_address_granter_address;

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/db/DbMigrationTester.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/db/DbMigrationTester.kt
@@ -1,0 +1,166 @@
+package tech.figure.objectstore.gateway.db
+
+import mu.KLogging
+import org.flywaydb.core.Flyway
+import org.jetbrains.exposed.sql.transactions.TransactionManager
+import tech.figure.objectstore.gateway.configuration.DataConfig
+import tech.figure.objectstore.gateway.configuration.DatabaseProperties
+import tech.figure.objectstore.gateway.db.DbMigrationHook.AfterAllMigrations
+import tech.figure.objectstore.gateway.db.DbMigrationHook.AfterMigration
+import tech.figure.objectstore.gateway.db.DbMigrationHook.BeforeMigration
+import tech.figure.objectstore.gateway.helpers.runRawSqlQuery
+import tech.figure.objectstore.gateway.helpers.runRawSqlUpdate
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DbMigrationTester(
+    private val databaseProperties: DatabaseProperties,
+    addDefaultHooks: Boolean = true,
+) {
+    private companion object : KLogging()
+    private val migrationHooks: MutableSet<DbMigrationHook> = mutableSetOf()
+
+    init {
+        if (addDefaultHooks) {
+            addAfterHook(version = "1.1", name = "Insert dummy scope_permissions record") {
+                // This ensures that transformations on this table don't cause exceptions after later migrations
+                // Runs raw sql because the latest exposed entity classes in the application don't support the old
+                // table format
+                runRawSqlUpdate(
+                    """
+                    INSERT INTO scope_permissions (id, scope_address, grantee_address, granter_address, created)
+                    VALUES (1, 'scope-addr', 'grantee-addr', 'granter-addr', '2021-01-01T12:00Z');
+                    """.trimIndent()
+                )
+            }
+            addAfterHook(version = "3.1", name = "Verify dummy record") {
+                runRawSqlQuery("select scope_address, grantee_address, granter_address, grant_id from scope_permissions where id = 1") { resultSet ->
+                    resultSet.next()
+                    assertEquals(
+                        expected = "scope-addr",
+                        actual = resultSet.getString("scope_address"),
+                        message = "The scope_address column value of the dummy record should not be affected by the grant id migration",
+                    )
+                    assertEquals(
+                        expected = "grantee-addr",
+                        actual = resultSet.getString("grantee_address"),
+                        message = "The grantee_address column value of the dummy record should not be affected by the grant id migration",
+                    )
+                    assertEquals(
+                        expected = "granter-addr",
+                        actual = resultSet.getString("granter_address"),
+                        message = "The granter_address column value of the dummy record should not be affected by the grant id migration",
+                    )
+                    assertNull(
+                        actual = resultSet.getString("grant_id"),
+                        message = "The default grant id value should be null on the dummy record",
+                    )
+                }
+            }
+        }
+    }
+
+    fun addBeforeHook(
+        version: String,
+        name: String = "$version-beforeHook",
+        action: () -> Unit,
+    ): DbMigrationTester = this.apply {
+        assertTrue(
+            actual = beforeHooks().none { it.version == version },
+            message = "A before hook for migration version [$version] has already been registered",
+        )
+        migrationHooks += BeforeMigration(
+            name = name,
+            version = version,
+            action = action,
+        )
+    }
+
+    fun addAfterHook(
+        version: String,
+        name: String = "$version-afterHook",
+        action: () -> Unit,
+    ): DbMigrationTester = this.apply {
+        assertTrue(
+            actual = afterHooks().none { it.version == version },
+            message = "An after hook for migration version [$version] has already been registered",
+        )
+        migrationHooks += AfterMigration(
+            name = name,
+            version = version,
+            action = action,
+        )
+    }
+
+    fun addAfterAllHook(
+        name: String,
+        action: () -> Unit,
+    ): DbMigrationTester = this.apply {
+        assertTrue(
+            actual = afterAllHooks().none { it.name == name },
+            message = "An after all migrations hook with name [$name] has already been registered",
+        )
+        migrationHooks += AfterAllMigrations(name = name, action = action)
+    }
+
+    fun testMigrations() {
+        val dataConfig = DataConfig()
+        val dataSource = dataConfig.dataSource(databaseProperties)
+        // Init exposed to ensure transactions run in this process are able to do things without blowing up
+        val database = dataConfig.databaseConnect(dataSource, databaseProperties)
+        val flywayConfig = dataConfig.flywayConfig(dataSource, databaseProperties)
+        Flyway(flywayConfig).info().all().forEach { migration ->
+            val migrationPrefix = "[MIGRATION ${migration.version}: ${migration.description}]"
+            logger.info("$migrationPrefix START PROCESS")
+            beforeHookOrNull(migration.version.version)?.also { beforeHook ->
+                logger.info("$migrationPrefix Running BEFORE hook [${beforeHook.name}]")
+                beforeHook.action()
+            }
+            logger.info("$migrationPrefix RUNNING MIGRATION")
+            Flyway(flywayConfig.target(migration.version)).migrate()
+            logger.info("$migrationPrefix MIGRATION COMPLETED")
+            afterHookOrNull(migration.version.version)?.also { afterHook ->
+                logger.info("$migrationPrefix Running AFTER hook [${afterHook.name}]")
+                afterHook.action()
+            }
+        }
+        afterAllHooks().forEach { afterAllHook ->
+            val hookPrefix = "[AFTER ALL HOOK ${afterAllHook.name}]"
+            logger.info("$hookPrefix STARTING HOOK")
+            afterAllHook.action()
+            logger.info("$hookPrefix COMPLETED HOOK")
+        }
+        // Unhook the database used for the test to ensure no conflicts with other tests occur
+        TransactionManager.closeAndUnregister(database)
+    }
+
+    private fun beforeHooks(): List<BeforeMigration> = migrationHooks.filterIsInstance<BeforeMigration>()
+    private fun afterHooks(): List<AfterMigration> = migrationHooks.filterIsInstance<AfterMigration>()
+    private fun afterAllHooks(): List<AfterAllMigrations> = migrationHooks.filterIsInstance<AfterAllMigrations>()
+
+    private fun beforeHookOrNull(version: String): DbMigrationHook? = beforeHooks()
+        .singleOrNull { it.version == version }
+
+    private fun afterHookOrNull(version: String): DbMigrationHook? = afterHooks()
+        .singleOrNull { it.version == version }
+}
+
+sealed interface DbMigrationHook {
+    val name: String
+    val action: () -> Unit
+
+    data class BeforeMigration(
+        override val name: String,
+        val version: String,
+        override val action: () -> Unit,
+    ) : DbMigrationHook
+
+    data class AfterMigration(
+        override val name: String,
+        val version: String,
+        override val action: () -> Unit,
+    ) : DbMigrationHook
+
+    data class AfterAllMigrations(override val name: String, override val action: () -> Unit) : DbMigrationHook
+}

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/db/MemoryMigrationsTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/db/MemoryMigrationsTest.kt
@@ -1,0 +1,42 @@
+package tech.figure.objectstore.gateway.db
+
+import mu.KLogging
+import org.jetbrains.exposed.sql.transactions.TransactionManager
+import org.jetbrains.exposed.sql.transactions.transaction
+import tech.figure.objectstore.gateway.configuration.DatabaseProperties
+import tech.figure.objectstore.gateway.helpers.runRawSqlUpdate
+import kotlin.test.Test
+
+class MemoryMigrationsTest {
+    private companion object : KLogging()
+
+    @Test
+    fun `test memory migrations`() {
+        val properties = DatabaseProperties(
+            type = "memory",
+            name = "object-store-gateway",
+            username = "user",
+            password = "pass",
+            host = "migrationTest",
+            port = "",
+            schema = "object-store-gateway",
+            connectionPoolSize = "1",
+            baselineOnMigrate = false,
+        )
+        DbMigrationTester(properties).removeDatabaseTables().testMigrations()
+    }
+
+    /**
+     * The in-memory configuration uses a shared cache, which means the tables will remain in existence when other
+     * tests start running.  This will cause Flyway issues when other in-memory config tests start up.  To remedy this,
+     * just remove all data that the tests caused to be created by clearing all tables.
+     */
+    private fun DbMigrationTester.removeDatabaseTables(): DbMigrationTester = this.addAfterAllHook(name = "remove in-memory tables") {
+        val tableNames = transaction { TransactionManager.current().db.dialect.allTablesNames() }.distinct()
+        logger.info("Successfully fetched [${tableNames.size}] table names to delete")
+        tableNames.forEach { tableName ->
+            logger.info("DROPPING TABLE $tableName")
+            runRawSqlUpdate("drop table $tableName")
+        }
+    }
+}

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/db/PostgresqlMigrationsTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/db/PostgresqlMigrationsTest.kt
@@ -1,0 +1,65 @@
+package tech.figure.objectstore.gateway.db
+
+import mu.KLogging
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.Network
+import org.testcontainers.containers.PostgreSQLContainer
+import tech.figure.objectstore.gateway.configuration.DatabaseProperties
+import java.util.UUID
+import kotlin.test.fail
+
+class PostgresqlMigrationsTest {
+    private companion object : KLogging()
+
+    lateinit var network: Network
+
+    @BeforeEach
+    fun setupTestContainers() {
+        network = Network.builder().createNetworkCmdModifier {
+            it.withName("postgresql-tests-network-${UUID.randomUUID()}")
+        }.build()
+    }
+
+    @Test
+    fun `test postgresql 11 migrations`() {
+        val properties = getPostgresqlContainer("11-alpine").toDatabaseProperties()
+        DbMigrationTester(properties).testMigrations()
+    }
+
+    @Test
+    fun `test postgresql 13 migrations`() {
+        val properties = getPostgresqlContainer("13-alpine").toDatabaseProperties()
+        DbMigrationTester(properties).testMigrations()
+    }
+
+    private fun getPostgresqlContainer(version: String): PostgreSQLContainer<*> = PostgreSQLContainer("postgres:$version")
+        .withNetwork(network)
+        .withNetworkMode(network.id)
+        .withNetworkAliases("postgres")
+        .withDatabaseName("object-store-gateway")
+        .withUsername("user")
+        .withPassword("pass")
+        .withCommand("postgres", "-c", "integrationtest.safe=1", "-c", "fsync=off")
+        .also {
+            try {
+                logger.info("Starting PostgreSQL container with version [$version]")
+                it.start()
+                logger.info("Successfully started PostgreSQL container with version [$version]")
+            } catch (e: Exception) {
+                fail("Failed to start PostgreSQL container with version [$version]", e)
+            }
+        }
+
+    private fun PostgreSQLContainer<*>.toDatabaseProperties(): DatabaseProperties = DatabaseProperties(
+        type = "postgresql",
+        name = this.databaseName,
+        username = this.username,
+        password = this.password,
+        host = this.host,
+        port = this.getMappedPort(5432).toString(),
+        schema = "object-store-gateway",
+        connectionPoolSize = "1",
+        baselineOnMigrate = false,
+    )
+}

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/db/SqliteMigrationsTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/db/SqliteMigrationsTest.kt
@@ -1,0 +1,25 @@
+package tech.figure.objectstore.gateway.db
+
+import tech.figure.objectstore.gateway.configuration.DatabaseProperties
+import java.nio.file.Files
+import kotlin.io.path.pathString
+import kotlin.test.Test
+
+class SqliteMigrationsTest {
+    @Test
+    fun `test sqlite migrations`() {
+        val dbDirectory = Files.createTempDirectory("os-gateway-sqlite")
+        val properties = DatabaseProperties(
+            type = "sqlite",
+            name = "object-store-gateway",
+            username = "user",
+            password = "pass",
+            host = dbDirectory.pathString,
+            port = "",
+            schema = "object-store-gateway",
+            connectionPoolSize = "1",
+            baselineOnMigrate = false,
+        )
+        DbMigrationTester(properties).testMigrations()
+    }
+}

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/helpers/QueryHelpers.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/helpers/QueryHelpers.kt
@@ -2,8 +2,10 @@ package tech.figure.objectstore.gateway.helpers
 
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transaction
 import tech.figure.objectstore.gateway.model.ScopePermissionsTable
+import java.sql.ResultSet
 
 fun queryGrantCount(
     scopeAddr: String,
@@ -35,4 +37,27 @@ fun queryGrantCount(
                 }
             }
     }.count()
+}
+
+/**
+ * Easy way to execute a SQL update in-place anywhere in an int test.
+ * This could potentially allow sql injection, so don't go replicatin' it in some production code, now, y'hear!?
+ */
+fun runRawSqlUpdate(sql: String): Int = transaction {
+    val connection = TransactionManager.current().connection
+    val statement = connection.prepareStatement(sql, false)
+    statement.executeUpdate()
+}
+
+/**
+ * Easy way to execute a SQL query in-place anywhere in an int test.
+ * This could potentially allow sql injection, so don't go replicatin' it in some production code!!!!!!!!!!AHHHHH!!!!
+ *
+ * @param useResultSet The ResultSet is closed after the transaction exits, so this function allows the values to be
+ * consumed before the transaction is closed.
+ */
+fun runRawSqlQuery(sql: String, useResultSet: (ResultSet) -> Unit = {}) = transaction {
+    val connection = TransactionManager.current().connection
+    val statement = connection.prepareStatement(sql, false)
+    statement.executeQuery().also(useResultSet)
 }


### PR DESCRIPTION
# Description
This PR adds testing against each database type, ensuring that all migrations can be run against the given database without issue.  The `DbMigrationTester` may need to be updated in the future when/if new migrations are added that later the format of various tables.

## Changes
- Add a new env param, `DB_REPAIR_FLYWAY_CHECKSUMS`, that allows old migrations to be repaired and automatically recover the database's checksums when a new deployment occurs.  Without this enabled, edits to old migrations would not be possible.
- Introduce "testContainers" code into the tests.  This allows simulation of PostgreSQL to be done in tests with relative ease.
- Edit the PostgreSQL migration `V3_0__Remove_Scope_Permissions_Unique_Index.sql` to safely remove the constraint and index.
- Add a `DbMigrationTester` class that drives testing all flyway migrations against a configured database source.
- Add helper functions to the int tests for executing raw sql.