### PR TITLE
Feature: Bech32 Verification in ScopePermissionsService

### DIFF
--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/service/AddressVerificationService.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/service/AddressVerificationService.kt
@@ -15,16 +15,41 @@ class AddressVerificationService(private val provenanceProperties: ProvenancePro
         private const val SCOPE_HRP: String = "scope"
     }
 
+    /**
+     * Verifies that the input address is in proper bech32 format.  Ensures that the hrp in the address is the proper
+     * value for the configured Provenance Blockchain network type (pb for mainnet and tp for testnet).  This function
+     * will return a Bech32Verification indicating the results of the verification, and is guaranteed to never throw
+     * exceptions.
+     *
+     * @param address The bech32 account address to verify.
+     */
     fun verifyAccountAddress(address: String): Bech32Verification = validateBech32Address(
         address = address,
         expectedHrp = if (provenanceProperties.mainNet) MAINNET_HRP else TESTNET_HRP,
     )
 
+    /**
+     * Verifies that the input address is in proper bech32 format.  Ensures that the hrp in the address is the proper
+     * identifier for a Provenance Blockchain Metadata Scope, "scope."  This function will return a Bech32Verification
+     * indicating the results of the verification, and it is guaranteed to never throw exceptions.
+     *
+     * @param address The bech32 scope address to verify.
+     */
     fun verifyScopeAddress(address: String): Bech32Verification = validateBech32Address(
         address = address,
         expectedHrp = SCOPE_HRP,
     )
 
+    /**
+     * Internal function that processes all bech32 address verification.  This leverages the Provenance Blockchain
+     * Scope Util library's Bech32 helper class to ensure that the address is properly-formed and passes checksum
+     * validation.  This function will return a Bech32Verification indicating the hrp on success, or information about
+     * failures when they occur.
+     *
+     * @param address Any bech32 address to verify.
+     * @param expectedHrp The human-readable-prefix expected for the input address.  A failure is returned if the
+     * input address's hrp does not match this value.
+     */
     private fun validateBech32Address(address: String, expectedHrp: String): Bech32Verification = try {
         val bech32Data = Bech32.decode(address)
         if (bech32Data.hrp == expectedHrp) {
@@ -37,10 +62,28 @@ class AddressVerificationService(private val provenanceProperties: ProvenancePro
     }
 }
 
+/**
+ * Encapsulates the different response values that can be emitted by the AddressVerificationService.
+ *
+ * @value address The bech32 address that was verified.
+ */
 sealed interface Bech32Verification {
     val address: String
 
+    /**
+     * Indicates that the input bech32 address was successfully verified as the anticipated address type.
+     *
+     * @param hrp The identified human-readable-prefix in the address.
+     */
     data class Success(override val address: String, val hrp: String) : Bech32Verification
+
+    /**
+     * Indicates that the input bech32 address was detected as invalid for the anticipated address type.
+     *
+     * @param cause An exception that was emitted during the verification process.  A null value indicates that the
+     * failure was not caused by an exception.
+     * @param message A message describing the reason that the address cannot be verified.
+     */
     data class Failure(
         override val address: String,
         val cause: Exception? = null,

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/service/AddressVerificationService.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/service/AddressVerificationService.kt
@@ -1,0 +1,49 @@
+package tech.figure.objectstore.gateway.service
+
+import io.provenance.scope.util.Bech32
+import mu.KLogging
+import org.springframework.stereotype.Service
+import tech.figure.objectstore.gateway.configuration.ProvenanceProperties
+import tech.figure.objectstore.gateway.service.Bech32Verification.Failure
+import tech.figure.objectstore.gateway.service.Bech32Verification.Success
+
+@Service
+class AddressVerificationService(private val provenanceProperties: ProvenanceProperties) {
+    private companion object : KLogging() {
+        private const val MAINNET_HRP: String = "pb"
+        private const val TESTNET_HRP: String = "tp"
+        private const val SCOPE_HRP: String = "scope"
+    }
+
+    fun verifyAccountAddress(address: String): Bech32Verification = validateBech32Address(
+        address = address,
+        expectedHrp = if (provenanceProperties.mainNet) MAINNET_HRP else TESTNET_HRP,
+    )
+
+    fun verifyScopeAddress(address: String): Bech32Verification = validateBech32Address(
+        address = address,
+        expectedHrp = SCOPE_HRP,
+    )
+
+    private fun validateBech32Address(address: String, expectedHrp: String): Bech32Verification = try {
+        val bech32Data = Bech32.decode(address)
+        if (bech32Data.hrp == expectedHrp) {
+            Success(address = address, hrp = bech32Data.hrp)
+        } else {
+            Failure(address = address, message = "Expected hrp [$expectedHrp] for address [$address]")
+        }
+    } catch (e: Exception) {
+        Failure(address = address, cause = e)
+    }
+}
+
+sealed interface Bech32Verification {
+    val address: String
+
+    data class Success(override val address: String, val hrp: String) : Bech32Verification
+    data class Failure(
+        override val address: String,
+        val cause: Exception? = null,
+        val message: String = cause?.message ?: "Bech32 validation failed for input address [$address]",
+    ) : Bech32Verification
+}

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/service/AddressVerificationService.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/service/AddressVerificationService.kt
@@ -51,9 +51,11 @@ class AddressVerificationService(private val provenanceProperties: ProvenancePro
      * input address's hrp does not match this value.
      */
     private fun validateBech32Address(address: String, expectedHrp: String): Bech32Verification = try {
-        val bech32Data = Bech32.decode(address)
-        if (bech32Data.hrp == expectedHrp) {
-            Success(address = address, hrp = bech32Data.hrp)
+        val derivedHrp = Bech32.decode(address).hrp.lowercase()
+        // Bech32 is valid if it is all uppercase or all lowercase.  Normalize case to ensure the input is not rejected
+        // for simply being a different format
+        if (derivedHrp == expectedHrp.lowercase()) {
+            Success(address = address, hrp = derivedHrp)
         } else {
             Failure(address = address, message = "Expected hrp [$expectedHrp] for address [$address]")
         }

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/service/AddressVerificationService.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/service/AddressVerificationService.kt
@@ -87,6 +87,6 @@ sealed interface Bech32Verification {
     data class Failure(
         override val address: String,
         val cause: Exception? = null,
-        val message: String = cause?.message ?: "Bech32 validation failed for input address [$address]",
+        val message: String = cause?.message ?: "Bech32 verification failed for input address [$address]",
     ) : Bech32Verification
 }

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/service/ScopePermissionsService.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/service/ScopePermissionsService.kt
@@ -10,6 +10,7 @@ import tech.figure.objectstore.gateway.repository.ScopePermissionsRepository
 @Service
 class ScopePermissionsService(
     @Qualifier(BeanQualifiers.OBJECTSTORE_PRIVATE_KEYS) private val accountAddresses: Set<String>,
+    private val addressVerificationService: AddressVerificationService,
     private val scopeFetchService: ScopeFetchService,
     private val scopePermissionsRepository: ScopePermissionsRepository,
 ) {
@@ -44,6 +45,16 @@ class ScopePermissionsService(
     ): GrantResponse {
         return try {
             val logPrefix = "[GATEWAY GRANT ${if (sourceDetails != null) "($sourceDetails)" else ""}]:"
+            // Verify that the scope address and all provided addresses are valid bech32 before attempting to process
+            // then through the remaining portions of the function
+            verifyAddressFailures(
+                scopeAddress = scopeAddress,
+                accountAddresses = listOf(
+                    granteeAddress to "Grantee",
+                    *grantSourceAddresses.map { it to "Source Address" }.toTypedArray(),
+                    *additionalAuthorizedAddresses.map { it to "Additional Authorized Address" }.toTypedArray(),
+                ),
+            )?.also { failureMessage -> return GrantResponse.Rejected("$logPrefix $failureMessage") }
             val scopeResponse = scopeFetchService.fetchScope(
                 scopeAddress = scopeAddress,
                 includeSessions = true,
@@ -99,6 +110,16 @@ class ScopePermissionsService(
         sourceDetails: String? = null,
     ): RevokeResponse = try {
         val logPrefix = "[GATEWAY REVOKE ${if (sourceDetails != null) "($sourceDetails)" else ""}]:"
+        // Verify that the scope address and all provided addresses are valid bech32 before attempting to process
+        // then through the remaining portions of the function
+        verifyAddressFailures(
+            scopeAddress = scopeAddress,
+            accountAddresses = listOf(
+                granteeAddress to "Grantee",
+                *revokeSourceAddresses.map { it to "Source Address" }.toTypedArray(),
+                *additionalAuthorizedAddresses.map { it to "Additional Authorized Address" }.toTypedArray(),
+            ),
+        )?.also { failureMessage -> return RevokeResponse.Rejected("$logPrefix $failureMessage") }
         val scopeResponse = scopeFetchService.fetchScope(scopeAddress = scopeAddress)
         // TODO: Add authz reverse lookup to attempt to find additional authorized addresses.  The scope's value owner
         // may have granted other addresses the required privileges that should allow this to proceed
@@ -140,6 +161,31 @@ class ScopePermissionsService(
      * Extension function to determine if the value is contained in the registered object store deserialization addresses.
      */
     private fun String?.isWatchedAddress(): Boolean = this in accountAddresses
+
+    private fun verifyAddressFailures(
+        scopeAddress: String,
+        accountAddresses: List<Pair<String, String>>,
+    ): String? = listOfNotNull(
+        verifyAddress(
+            verification = addressVerificationService.verifyScopeAddress(scopeAddress),
+            verificationType = "Scope",
+        ),
+        *accountAddresses.mapNotNull { (accountAddress, verificationType) ->
+            verifyAddress(
+                verification = addressVerificationService.verifyAccountAddress(accountAddress),
+                verificationType = verificationType,
+            )
+        }.toTypedArray()
+    ).takeIf { it.isNotEmpty() }?.joinToString { it }
+
+    private fun verifyAddress(
+        verification: Bech32Verification,
+        verificationType: String,
+    ): String? = if (verification is Bech32Verification.Failure) {
+        "$verificationType Verification Failed for Address [${verification.address}]: ${verification.message}"
+    } else {
+        null
+    }
 }
 
 /**

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/service/ScopePermissionsService.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/service/ScopePermissionsService.kt
@@ -162,23 +162,32 @@ class ScopePermissionsService(
      */
     private fun String?.isWatchedAddress(): Boolean = this in accountAddresses
 
+    /**
+     * Verifies that all input addresses are valid bech32.  If any failures are detected, all failure messages are
+     * concatenated via CSV (default joinToString separator) and emitted.  If no failures are detected, the response
+     * will be null.
+     */
     private fun verifyAddressFailures(
         scopeAddress: String,
         accountAddresses: List<Pair<String, String>>,
     ): String? = listOfNotNull(
-        verifyAddress(
+        formatVerificationFailureOrNull(
             verification = addressVerificationService.verifyScopeAddress(scopeAddress),
             verificationType = "Scope",
         ),
         *accountAddresses.mapNotNull { (accountAddress, verificationType) ->
-            verifyAddress(
+            formatVerificationFailureOrNull(
                 verification = addressVerificationService.verifyAccountAddress(accountAddress),
                 verificationType = verificationType,
             )
         }.toTypedArray()
     ).takeIf { it.isNotEmpty() }?.joinToString { it }
 
-    private fun verifyAddress(
+    /**
+     * Creates a human-readable error message indicating the nature of a bech32 verification failure.  If no failure
+     * is detected, null is returned.
+     */
+    private fun formatVerificationFailureOrNull(
         verification: Bech32Verification,
         verificationType: String,
     ): String? = if (verification is Bech32Verification.Failure) {

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/helpers/ProvenanceAccountHelpers.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/helpers/ProvenanceAccountHelpers.kt
@@ -7,11 +7,11 @@ import io.provenance.hdwallet.wallet.Wallet
 import io.provenance.scope.encryption.model.DirectKeyRef
 import io.provenance.scope.encryption.model.KeyRef
 
-fun genRandomAccount(): Account = Wallet.fromMnemonic(
-    hrp = "tp",
+fun genRandomAccount(testnet: Boolean = true): Account = Wallet.fromMnemonic(
+    hrp = if (testnet) "tp" else "pb",
     passphrase = "",
     mnemonicWords = MnemonicWords.generate(strength = 256),
-    testnet = true,
+    testnet = testnet,
 )["m/44'/1'/0'/0/0'"]
 
 val Account.bech32Address: String

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/service/AddressVerificationServiceTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/service/AddressVerificationServiceTest.kt
@@ -1,0 +1,106 @@
+package tech.figure.objectstore.gateway.service
+
+import io.provenance.scope.util.MetadataAddress
+import tech.figure.objectstore.gateway.configuration.ProvenanceProperties
+import tech.figure.objectstore.gateway.helpers.bech32Address
+import tech.figure.objectstore.gateway.helpers.genRandomAccount
+import tech.figure.objectstore.gateway.service.Bech32Verification.Failure
+import tech.figure.objectstore.gateway.service.Bech32Verification.Success
+import java.net.URI
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AddressVerificationServiceTest {
+    @Test
+    fun `verifyAccountAddress properly processes mainnet addresses`() {
+        val service = getService(mainNet = true)
+        // Proves bech32 validation verifies checksums
+        assertFailedValidation(
+            verification = service.verifyAccountAddress("fa1keaddress"),
+            expectedMessage = "checksum failed",
+        )
+        // Proves bech32 validation requires mainnet when configured to do so
+        val testnetAddress = genRandomAccount(testnet = true).bech32Address
+        assertFailedValidation(
+            verification = service.verifyAccountAddress(testnetAddress),
+            expectedMessage = "Expected hrp [pb] for address [$testnetAddress]",
+        )
+        assertSuccessfulValidation(
+            verification = service.verifyAccountAddress(genRandomAccount(testnet = false).bech32Address),
+            expectedHrp = "pb",
+        )
+    }
+
+    @Test
+    fun `verifyAccountAddress properly processes testnet address`() {
+        val service = getService(mainNet = false)
+        // Proves bech32 validation verifies checksums
+        assertFailedValidation(
+            verification = service.verifyAccountAddress("tp1fakeaddress"),
+            expectedMessage = "checksum failed",
+        )
+        // Proves bech32 validation requires testnet when configured to do so
+        val mainnetAddress = genRandomAccount(testnet = false).bech32Address
+        assertFailedValidation(
+            verification = service.verifyAccountAddress(mainnetAddress),
+            expectedMessage = "Expected hrp [tp] for address [$mainnetAddress]",
+        )
+        assertSuccessfulValidation(
+            verification = service.verifyAccountAddress(genRandomAccount(testnet = true).bech32Address),
+            expectedHrp = "tp",
+        )
+    }
+
+    @Test
+    fun `verifyScopeAddress properly processes address`() {
+        val service = getService()
+        // Proves bech32 validation verifies checksums
+        assertFailedValidation(
+            verification = service.verifyScopeAddress("scope1fakeaddress"),
+            expectedMessage = "checksum failed",
+        )
+        // Proves scope addresses require the scope prefix
+        val address = genRandomAccount(testnet = false).bech32Address
+        assertFailedValidation(
+            verification = service.verifyScopeAddress(address),
+            expectedMessage = "Expected hrp [scope] for address [$address]",
+        )
+        assertSuccessfulValidation(
+            verification = service.verifyScopeAddress(MetadataAddress.forScope(UUID.randomUUID()).toString()),
+            expectedHrp = "scope",
+        )
+    }
+
+    private fun assertFailedValidation(verification: Bech32Verification, expectedMessage: String) {
+        assertTrue(
+            actual = verification is Failure,
+            message = "Expected validation to be failure, but was: $verification",
+        )
+        assertTrue(
+            actual = expectedMessage in verification.message,
+            message = "Expected validation message to be correctly formatted, but got: ${verification.message}",
+        )
+    }
+
+    private fun assertSuccessfulValidation(verification: Bech32Verification, expectedHrp: String) {
+        assertTrue(
+            actual = verification is Success,
+            message = "Expected validation to be success, but was: $verification",
+        )
+        assertEquals(
+            expected = expectedHrp,
+            actual = verification.hrp,
+            message = "Incorrect hrp derived from input",
+        )
+    }
+
+    private fun getService(mainNet: Boolean = false): AddressVerificationService = AddressVerificationService(
+        provenanceProperties = ProvenanceProperties(
+            mainNet = mainNet,
+            chainId = "chain-local",
+            channelUri = URI.create("http://localhost:9090"),
+        )
+    )
+}

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/service/AddressVerificationServiceTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/service/AddressVerificationServiceTest.kt
@@ -18,7 +18,7 @@ class AddressVerificationServiceTest {
         val service = getService(mainNet = true)
         // Proves bech32 validation verifies checksums
         assertFailedValidation(
-            verification = service.verifyAccountAddress("fa1keaddress"),
+            verification = service.verifyAccountAddress("pb1fakeaddress"),
             expectedMessage = "checksum failed",
         )
         // Proves bech32 validation requires mainnet when configured to do so

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/service/AddressVerificationServiceTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/service/AddressVerificationServiceTest.kt
@@ -27,8 +27,14 @@ class AddressVerificationServiceTest {
             verification = service.verifyAccountAddress(testnetAddress),
             expectedMessage = "Expected hrp [pb] for address [$testnetAddress]",
         )
+        // Verifies that lowercase input does not cause any issues
         assertSuccessfulValidation(
-            verification = service.verifyAccountAddress(genRandomAccount(testnet = false).bech32Address),
+            verification = service.verifyAccountAddress(genRandomAccount(testnet = false).bech32Address.lowercase()),
+            expectedHrp = "pb",
+        )
+        // Verifies that uppercase input does not cause any issues
+        assertSuccessfulValidation(
+            verification = service.verifyAccountAddress(genRandomAccount(testnet = false).bech32Address.uppercase()),
             expectedHrp = "pb",
         )
     }
@@ -47,8 +53,14 @@ class AddressVerificationServiceTest {
             verification = service.verifyAccountAddress(mainnetAddress),
             expectedMessage = "Expected hrp [tp] for address [$mainnetAddress]",
         )
+        // Verifies that lowercase input does not cause any issues
         assertSuccessfulValidation(
-            verification = service.verifyAccountAddress(genRandomAccount(testnet = true).bech32Address),
+            verification = service.verifyAccountAddress(genRandomAccount(testnet = true).bech32Address.lowercase()),
+            expectedHrp = "tp",
+        )
+        // Verifies that uppercase input does not cause any issues
+        assertSuccessfulValidation(
+            verification = service.verifyAccountAddress(genRandomAccount(testnet = true).bech32Address.uppercase()),
             expectedHrp = "tp",
         )
     }


### PR DESCRIPTION
# Description
This change ensures that bech32 values passed into the `ScopePermissionsService` are properly-formed, emitting rejections when any malformed values are detected.  This is essentially a big, fancy wrapper around the scope utils' `Bech32` class, which does the heavy lifting and can extract/check hrps + checksums, etc.

## Changes
* Create an `AddressVerificationService` that can properly validate incoming scope / account addresses.  This is flexible in that it can easily be expanded if we ever care about scopespecs, etc.
* Incorporate `AddressVerificationService` in the `ScopePermissionsService` to ensure incoming values aren't ever pointing at invalid bech32, preventing weird grants being added to the database and/or potential bad actor stuff.