### PR TITLE
Feature: Always allow the master key to store objects

### DIFF
--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/components/EventStreamConsumer.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/components/EventStreamConsumer.kt
@@ -67,7 +67,14 @@ class EventStreamConsumer(
                     .txEvents(block.block.header?.dateTime()) { index -> block.block.txData(index) }
                     .filter { TX_EVENTS.contains(it.eventType) } // these are the blocks you are looking for
                     .forEach {
-                        streamEventHandlerService.handleEvent(it)
+                        try {
+                            streamEventHandlerService.handleEvent(it)
+                        } catch (e: Exception) {
+                            // If exceptions are simply thrown without any additional logging, the errors appear to be
+                            // event stream related, which would not be the case if they occur in this block
+                            logger.error("Failed to process event with hash ${it.txHash} at height ${it.blockHeight}", e)
+                            throw e
+                        }
                     }
 
                 if (block.height < lastProcessedHeight) {

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/service/ObjectService.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/service/ObjectService.kt
@@ -26,9 +26,12 @@ class ObjectService(
     private val objectPermissionsRepository: ObjectPermissionsRepository,
     private val provenanceProperties: ProvenanceProperties,
 ) {
+    private val masterAddress = masterKey.publicKey.getAddress(provenanceProperties.mainNet)
+
     fun putObject(obj: GatewayOuterClass.ObjectWithMeta, requesterPublicKey: PublicKey, additionalAudienceKeys: List<PublicKey> = listOf()): String {
         val requesterAddress = requesterPublicKey.getAddress(provenanceProperties.mainNet)
-        if (!accountsRepository.isAddressEnabled(requesterAddress)) {
+        // Always allow the master key data storage rights
+        if (requesterAddress != masterAddress && !accountsRepository.isAddressEnabled(requesterAddress)) {
             throw AccessDeniedException("Object storage not granted to $requesterAddress")
         }
 


### PR DESCRIPTION
# Description
The master key should always be allowed to store objects.  The current flow requires that it add itself to the accounts repository, which doesn't make a ton of sense.  Additionally, the stream event handler has been wrapped in a try/catch, which will prevent the event stream from hiding errors that might occur in that service.