### PR TITLE
handle no private keys

### DIFF
--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/AppConfig.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/AppConfig.kt
@@ -23,11 +23,15 @@ class AppConfig {
     }
 
     @Bean(BeanQualifiers.OBJECTSTORE_ENCRYPTION_KEYS)
-    fun encryptionKeys(provenanceProperties: ProvenanceProperties, objectStoreProperties: ObjectStoreProperties): Map<String, KeyRef> = objectStoreProperties.privateKeys.map {
-        it.toJavaPrivateKey().toKeyPair().let { keyPair ->
-            keyPair.public.getAddress(provenanceProperties.mainNet) to DirectKeyRef(keyPair)
-        }
-    }.toMap()
+    fun encryptionKeys(provenanceProperties: ProvenanceProperties, objectStoreProperties: ObjectStoreProperties): Map<String, KeyRef> =
+        objectStoreProperties.privateKeys
+            .filterNot { it.isBlank() }
+            .filterNot { it.isEmpty() }
+            .map {
+                it.toJavaPrivateKey().toKeyPair().let { keyPair ->
+                    keyPair.public.getAddress(provenanceProperties.mainNet) to DirectKeyRef(keyPair)
+                }
+            }.toMap()
 
     @Bean(BeanQualifiers.OBJECTSTORE_MASTER_KEY)
     fun masterKey(objectStoreProperties: ObjectStoreProperties): KeyRef = objectStoreProperties.masterKey.toJavaPrivateKey().toKeyPair().let(::DirectKeyRef)

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/AppConfig.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/AppConfig.kt
@@ -26,7 +26,6 @@ class AppConfig {
     fun encryptionKeys(provenanceProperties: ProvenanceProperties, objectStoreProperties: ObjectStoreProperties): Map<String, KeyRef> =
         objectStoreProperties.privateKeys
             .filterNot { it.isBlank() }
-            .filterNot { it.isEmpty() }
             .map {
                 it.toJavaPrivateKey().toKeyPair().let { keyPair ->
                     keyPair.public.getAddress(provenanceProperties.mainNet) to DirectKeyRef(keyPair)


### PR DESCRIPTION
The `OBJECT_STORE_PRIVATE_KEYS` env var is required, but if the list is empty, then an error is thrown trying to parse an empty string. 

Encountered when creating a gateway deployment for the Broker-Dealer/ATS, and planning on only using put/get routes for signed documents.

```
Factory method 'encryptionKeys' threw exception; nested exception is org.bouncycastle.util.encoders.DecoderException: exception decoding Hex string: invalid characters encountered in Hex string
```