### PR TITLE
Bugfix: Use latest event stream binary

### DIFF
--- a/client/src/main/kotlin/tech/figure/objectstore/gateway/client/GatewayJwt.kt
+++ b/client/src/main/kotlin/tech/figure/objectstore/gateway/client/GatewayJwt.kt
@@ -72,6 +72,7 @@ sealed interface GatewayJwt {
      *
      * @param keyPair The public and private keys of the requesting entity.
      */
+    @Suppress("DEPRECATION")
     data class KeyPairJwt(val keyPair: KeyPair) : GatewayJwt {
         override fun createJwt(mainNet: Boolean, expiresAt: OffsetDateTime): String = createJwtInternal(
             publicKey = keyPair.public,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 asset-model = "0.1.2"
 bouncycastle = "1.70"
 exposed = "0.37.3"
-figure-eventstream = "0.7.1"
+figure-eventstream = "0.8.1"
 flyway = "8.0.2"
 grpc = "1.45.1" # If updating this value, ensure to update the doc reference in the ClientConfig class
 grpc-springboot = "3.4.3"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 asset-model = "0.1.2"
 bouncycastle = "1.70"
 exposed = "0.37.3"
-figure-eventstream = "0.8.0"
+figure-eventstream = "0.8.1"
 flyway = "8.0.2"
 grpc = "1.45.1" # If updating this value, ensure to update the doc reference in the ClientConfig class
 grpc-springboot = "3.4.3"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 asset-model = "0.1.2"
 bouncycastle = "1.70"
 exposed = "0.37.3"
-figure-eventstream = "0.8.1"
+figure-eventstream = "0.8.0"
 flyway = "8.0.2"
 grpc = "1.45.1" # If updating this value, ensure to update the doc reference in the ClientConfig class
 grpc-springboot = "3.4.3"

--- a/proto/build.gradle.kts
+++ b/proto/build.gradle.kts
@@ -52,11 +52,11 @@ dependencies {
 protobuf {
     // Configure the protoc executable
     protoc {
-        artifact = "com.google.protobuf:protoc:3.5.0"
+        artifact = "com.google.protobuf:protoc:${libs.versions.protobuf.get()}"
     }
     plugins {
         id("grpc") {
-            artifact = "io.grpc:protoc-gen-grpc-java:1.0.0-pre2"
+            artifact = "io.grpc:protoc-gen-grpc-java:1.42.1"
         }
     }
     generateProtoTasks {

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/service/JwtVerificationService.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/service/JwtVerificationService.kt
@@ -18,6 +18,7 @@ data class VerificationResult(val address: String, val publicKey: PublicKey)
 class JwtVerificationService {
     fun verifyJwtString(jwt: String) = verifyJwt(JWT.decode(jwt))
 
+    @Suppress("DEPRECATION")
     fun verifyJwt(jwt: DecodedJWT): VerificationResult {
         val publicKey = jwt.claims.get(Constants.JWT_PUBLIC_KEY)
             ?.asString()

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/service/StreamEventHandlerServiceTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/service/StreamEventHandlerServiceTest.kt
@@ -30,6 +30,7 @@ import tech.figure.objectstore.gateway.model.ScopePermission
 import tech.figure.objectstore.gateway.model.ScopePermissionsTable
 import tech.figure.objectstore.gateway.repository.ScopePermissionsRepository
 import tech.figure.objectstore.gateway.util.toByteString
+import java.math.BigInteger
 import java.time.OffsetDateTime
 import java.util.Base64
 import java.util.UUID
@@ -287,7 +288,7 @@ class StreamEventHandlerServiceTest {
         txHash: String = "txHash",
         eventType: String = "wasm",
         attributes: List<Pair<String, String>>,
-        fee: Long = 1000L,
+        fee: BigInteger = 1000L.toBigInteger(),
         denom: String = "nhash",
         note: String = "test event",
     ) {

--- a/shared/src/main/kotlin/tech/figure/objectstore/gateway/shared/KeyRefSecP256K1Algorithm.kt
+++ b/shared/src/main/kotlin/tech/figure/objectstore/gateway/shared/KeyRefSecP256K1Algorithm.kt
@@ -16,6 +16,7 @@ class KeyRefSecP256K1Algorithm(
         deterministic = false
     }
 
+    @Suppress("DEPRECATION")
     override fun verify(jwt: DecodedJWT) {
         // Delegate verification to regular ECDSA256K algo, since it only needs the public key
         JWT.require(ECDSA256K(signer.getPublicKey() as ECPublicKey, null))


### PR DESCRIPTION
# Description
The event stream had a bug that prevented it from processing a block with a large fee amount in it.  This uses the latest version that fixes this deserialization issue.  This also suppresses various deprecation warnings about using SECP algorithm because they were annoying and we can't change it.