### PR TITLE
Feature: Add object permissions grants

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -17,13 +17,15 @@ tasks.withType<KotlinCompile> {
 }
 
 dependencies {
-    api(projects.proto)
-    implementation(projects.shared)
     listOf(
+        projects.proto,
+        projects.shared,
         libs.bouncycastle,
         libs.java.jwt,
+        libs.coroutines.core.jvm,
+        libs.coroutines.jdk8,
         libs.bundles.grpc,
         libs.bundles.protobuf,
         libs.bundles.provenance,
-    ).forEach(::implementation)
+    ).forEach(::api)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ exposed = "0.37.3"
 figure-eventstream = "0.8.1"
 flyway = "8.0.2"
 grpc = "1.45.1" # If updating this value, ensure to update the doc reference in the ClientConfig class
+grpc-kotlin = "1.3.0"
 grpc-springboot = "3.4.3"
 hikari = "5.0.1"
 jackson = "2.12.5"
@@ -43,6 +44,7 @@ figure-eventstream-core = { module = "tech.figure.eventstream:es-core", version.
 flyway = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
 grpc-protobuf = { module = "io.grpc:grpc-protobuf", version.ref = "grpc" }
 grpc-stub = { module = "io.grpc:grpc-stub", version.ref = "grpc" }
+grpc-kotlin-stub = { module = "io.grpc:grpc-kotlin-stub", version.ref = "grpc-kotlin" }
 grpc-springboot-starter = { module = "io.github.lognet:grpc-spring-boot-starter", version.ref = "grpc-springboot" }
 grpc-netty = { module = "io.grpc:grpc-netty", version.ref = "grpc" }
 grpc-netty-shaded = { module = "io.grpc:grpc-netty-shaded", version.ref = "grpc" }
@@ -77,6 +79,7 @@ springboot-starter-web = { module = "org.springframework.boot:spring-boot-starte
 sqlite = { module = "org.xerial:sqlite-jdbc", version.ref = "sqlite" }
 
 # Test
+coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 springboot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
@@ -86,7 +89,7 @@ testcontainers-postgres = { module = "org.testcontainers:postgresql", version.re
 [bundles]
 database = ["exposed-core", "exposed-dao", "exposed-jdbc", "flyway", "hikari", "postgres", "sqlite"]
 eventstream = ["figure-eventstream-api", "figure-eventstream-api-model", "figure-eventstream-cli", "figure-eventstream-core"]
-grpc = ["grpc-netty", "grpc-netty-shaded", "grpc-protobuf", "grpc-stub", "grpc-springboot-starter"]
+grpc = ["grpc-netty", "grpc-netty-shaded", "grpc-protobuf", "grpc-stub", "grpc-springboot-starter", "grpc-kotlin-stub"]
 jackson = ["jackson-module-kotlin", "jackson-module-protobuf"]
 kotlin = ["coroutines-core-jvm", "coroutines-reactor", "coroutines-jdk8", "coroutines-slf4j", "kotlin-allopen", "kotlin-reflect", "kotlin-stdlib-jdk8"]
 logging = ["kotlin-logging"]

--- a/proto/build.gradle.kts
+++ b/proto/build.gradle.kts
@@ -43,7 +43,9 @@ dependencies {
     implementation("javax.annotation:javax.annotation-api:1.3.2")
     listOf(
         libs.bundles.protobuf,
-        libs.bundles.grpc
+        libs.bundles.grpc,
+        libs.coroutines.core.jvm,
+        libs.coroutines.jdk8,
     ).forEach(::implementation)
 
     protobuf(libs.provenance.scope.proto)
@@ -56,7 +58,10 @@ protobuf {
     }
     plugins {
         id("grpc") {
-            artifact = "io.grpc:protoc-gen-grpc-java:1.42.1"
+            artifact = "io.grpc:protoc-gen-grpc-java:${libs.versions.grpc.asProvider().get()}"
+        }
+        id("grpckt") {
+            artifact = "io.grpc:protoc-gen-grpc-kotlin:${libs.versions.grpc.kotlin.get()}:jdk8@jar"
         }
     }
     generateProtoTasks {
@@ -67,6 +72,7 @@ protobuf {
                 // plugin will not be added. This is because of the implicit way
                 // NamedDomainObjectContainer binds the methods.
                 id("grpc")
+                id("grpckt")
             }
         }
     }

--- a/proto/src/main/proto/tech/figure/objectstore/gateway/gateway.proto
+++ b/proto/src/main/proto/tech/figure/objectstore/gateway/gateway.proto
@@ -9,6 +9,8 @@ service Gateway {
   rpc PutObject (PutObjectRequest) returns (PutObjectResponse) {};
   rpc RegisterExistingObject (RegisterExistingObjectRequest) returns (RegisterExistingObjectResponse) {};
   rpc FetchObjectByHash (FetchObjectByHashRequest) returns (FetchObjectByHashResponse) {};
+  rpc GrantObjectPermissions (GrantObjectPermissionsRequest) returns (GrantObjectPermissionsResponse) {};
+  rpc BatchGrantObjectPermissions (BatchGrantObjectPermissionRequest) returns (stream GrantObjectPermissionsResponse) {};
   rpc RevokeObjectPermissions (RevokeObjectPermissionsRequest) returns (RevokeObjectPermissionsResponse) {};
   rpc GrantScopePermission (GrantScopePermissionRequest) returns (GrantScopePermissionResponse) {};
   rpc BatchGrantScopePermission (BatchGrantScopePermissionRequest) returns (BatchGrantScopePermissionResponse) {};
@@ -56,6 +58,22 @@ message FetchObjectByHashResponse {
   ObjectWithMeta object = 1;
 }
 
+message GrantObjectPermissionsRequest {
+  string grantee_address = 1; // A bech32 account address. This grantee will receive an object grant for the target hash
+  string hash = 2; // The hash of the object for which to grant permissions
+}
+
+message GrantObjectPermissionsResponse {
+  GrantObjectPermissionsRequest request = 1; // The request that invoked this action
+}
+
+message BatchGrantObjectPermissionRequest {
+  oneof grant_target {
+    AllHashesObjectGrantTarget all_hashes = 1; // Specifies that all hashes submitted by the granter will receive an object grant
+    SpecifiedHashesObjectGrantTarget specified_hashes = 2; // Specifies that all target hashes submitted by the granter will receive an object grant for the grantee
+  }
+}
+
 message RevokeObjectPermissionsRequest {
   string hash = 1; // the hash of the object to revoke permissions for
   repeated string grantee_address = 2; // the addresses to revoke access to this hash for
@@ -96,6 +114,17 @@ message RevokeScopePermissionResponse {
   RevokeScopePermissionRequest request = 1; // The request that evoked this response
   int32 revoked_grants_count = 2; // The amount of grants that the request successfully revoked
   bool revoke_accepted = 3; // If true, the revoke was successfully processed.  This indicates that the sender had the rights to make the request, even if zero grants were revoked based on the input
+}
+
+// Specifies that all hashes submitted by the granter will receive an object grant for the grantee
+message AllHashesObjectGrantTarget {
+  string grantee_address = 1; // A bech32 account address. Adds an object grant from the granter to all objects submitted by the granter
+}
+
+// Specifies that all target hashes submitted by the granter will receive an object grant for the grantee
+message SpecifiedHashesObjectGrantTarget {
+  string grantee_address = 1; // A bech32 account address. Adds an object grant from the granter to the target hashes
+  repeated string target_hashes = 2; // All hashes for which to grant permissions
 }
 
 message ObjectWithMeta {

--- a/proto/src/main/proto/tech/figure/objectstore/gateway/gateway.proto
+++ b/proto/src/main/proto/tech/figure/objectstore/gateway/gateway.proto
@@ -10,7 +10,7 @@ service Gateway {
   rpc RegisterExistingObject (RegisterExistingObjectRequest) returns (RegisterExistingObjectResponse) {};
   rpc FetchObjectByHash (FetchObjectByHashRequest) returns (FetchObjectByHashResponse) {};
   rpc GrantObjectPermissions (GrantObjectPermissionsRequest) returns (GrantObjectPermissionsResponse) {};
-  rpc BatchGrantObjectPermissions (BatchGrantObjectPermissionRequest) returns (stream GrantObjectPermissionsResponse) {};
+  rpc BatchGrantObjectPermissions (BatchGrantObjectPermissionsRequest) returns (stream GrantObjectPermissionsResponse) {};
   rpc RevokeObjectPermissions (RevokeObjectPermissionsRequest) returns (RevokeObjectPermissionsResponse) {};
   rpc GrantScopePermission (GrantScopePermissionRequest) returns (GrantScopePermissionResponse) {};
   rpc BatchGrantScopePermission (BatchGrantScopePermissionRequest) returns (BatchGrantScopePermissionResponse) {};
@@ -64,10 +64,11 @@ message GrantObjectPermissionsRequest {
 }
 
 message GrantObjectPermissionsResponse {
-  GrantObjectPermissionsRequest request = 1; // The request that invoked this action
+  string grantee_address = 1; // A bech32 account address. This grantee received an object grant for the target hash
+  string hash = 2; // The hash of the object for which permissions were granted
 }
 
-message BatchGrantObjectPermissionRequest {
+message BatchGrantObjectPermissionsRequest {
   oneof grant_target {
     AllHashesObjectGrantTarget all_hashes = 1; // Specifies that all hashes submitted by the granter will receive an object grant
     SpecifiedHashesObjectGrantTarget specified_hashes = 2; // Specifies that all target hashes submitted by the granter will receive an object grant for the grantee

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     ).forEach(::implementation)
 
     listOf(
+        libs.coroutines.test,
         libs.springboot.starter.test,
         libs.bundles.test.kotlin,
         libs.bundles.testcontainers,

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/ObjectStoreGatewayApplication.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/ObjectStoreGatewayApplication.kt
@@ -4,6 +4,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
 import org.springframework.scheduling.annotation.EnableScheduling
+import tech.figure.objectstore.gateway.configuration.BatchProperties
 import tech.figure.objectstore.gateway.configuration.DatabaseProperties
 import tech.figure.objectstore.gateway.configuration.EventStreamProperties
 import tech.figure.objectstore.gateway.configuration.ObjectStoreProperties
@@ -12,6 +13,7 @@ import tech.figure.objectstore.gateway.configuration.ProvenanceProperties
 @SpringBootApplication
 @EnableConfigurationProperties(
     value = [
+        BatchProperties::class,
         EventStreamProperties::class,
         ObjectStoreProperties::class,
         ProvenanceProperties::class,

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/AppProperties.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/AppProperties.kt
@@ -8,6 +8,14 @@ import java.net.URI
 import java.util.UUID
 
 @ConstructorBinding
+@ConfigurationProperties(prefix = "batch")
+@Validated
+data class BatchProperties(
+    val maxProvidedRecords: Int,
+    val threadCount: Int,
+)
+
+@ConstructorBinding
 @ConfigurationProperties(prefix = "event.stream")
 @Validated
 data class EventStreamProperties(

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/BeanQualifiers.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/BeanQualifiers.kt
@@ -1,6 +1,7 @@
 package tech.figure.objectstore.gateway.configuration
 
 object BeanQualifiers {
+    const val BATCH_PROCESS_COROUTINE_SCOPE_QUALIFIER = "batchProcessCoroutineScopeBean"
     const val EVENT_STREAM_COROUTINE_SCOPE_QUALIFIER = "eventStreamCoroutineScopeBean"
     const val OBJECTSTORE_ENCRYPTION_KEYS: String = "objectStoreEncryptionKeys"
     const val OBJECTSTORE_PRIVATE_KEYS: String = "objectStorePrivateKeys"

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/CoroutineConfig.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/CoroutineConfig.kt
@@ -7,6 +7,12 @@ import tech.figure.objectstore.gateway.util.CoroutineUtil
 
 @Configuration
 class CoroutineConfig {
+    @Bean(BeanQualifiers.BATCH_PROCESS_COROUTINE_SCOPE_QUALIFIER)
+    fun batchProcessScope(batchProperties: BatchProperties): CoroutineScope = CoroutineUtil.newSingletonScope(
+        scopeName = CoroutineScopeNames.BATCH_PROCESS_SCOPE,
+        threadCount = batchProperties.threadCount,
+    )
+
     @Bean(BeanQualifiers.EVENT_STREAM_COROUTINE_SCOPE_QUALIFIER)
     fun eventStreamScope(eventStreamProperties: EventStreamProperties): CoroutineScope = CoroutineUtil.newSingletonScope(
         scopeName = CoroutineScopeNames.EVENT_STREAM_SCOPE,
@@ -15,5 +21,6 @@ class CoroutineConfig {
 }
 
 object CoroutineScopeNames {
+    const val BATCH_PROCESS_SCOPE = "batchProcessCoroutineScope"
     const val EVENT_STREAM_SCOPE = "eventStreamCoroutineScope"
 }

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/exception/GrpcExceptions.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/exception/GrpcExceptions.kt
@@ -4,9 +4,9 @@ import io.grpc.Status
 import io.grpc.StatusRuntimeException
 
 class AccessDeniedException(message: String?) : StatusRuntimeException(Status.PERMISSION_DENIED.withDescription(message))
-class ExistingGrantException(message: String?) : StatusRuntimeException(Status.ALREADY_EXISTS.withDescription(message))
 class InvalidInputException(message: String?) : StatusRuntimeException(Status.INVALID_ARGUMENT.withDescription(message))
 class JwtValidationException(message: String?, cause: Throwable? = null) : StatusRuntimeException(Status.PERMISSION_DENIED.withDescription(message).withCause(cause))
 class NotFoundException(message: String?) : StatusRuntimeException(Status.NOT_FOUND.withDescription(message))
+class ResourceAlreadyExistsException(message: String?) : StatusRuntimeException(Status.ALREADY_EXISTS.withDescription(message))
 class SignatureValidationException(message: String?) : StatusRuntimeException(Status.PERMISSION_DENIED.withDescription(message))
 class TimestampValidationException(message: String?) : StatusRuntimeException(Status.PERMISSION_DENIED.withDescription(message))

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/exception/GrpcExceptions.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/exception/GrpcExceptions.kt
@@ -4,6 +4,8 @@ import io.grpc.Status
 import io.grpc.StatusRuntimeException
 
 class AccessDeniedException(message: String?) : StatusRuntimeException(Status.PERMISSION_DENIED.withDescription(message))
+class ExistingGrantException(message: String?) : StatusRuntimeException(Status.ALREADY_EXISTS.withDescription(message))
+class InvalidInputException(message: String?) : StatusRuntimeException(Status.INVALID_ARGUMENT.withDescription(message))
 class JwtValidationException(message: String?, cause: Throwable? = null) : StatusRuntimeException(Status.PERMISSION_DENIED.withDescription(message).withCause(cause))
 class NotFoundException(message: String?) : StatusRuntimeException(Status.NOT_FOUND.withDescription(message))
 class SignatureValidationException(message: String?) : StatusRuntimeException(Status.PERMISSION_DENIED.withDescription(message))

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/model/ObjectPermissions.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/model/ObjectPermissions.kt
@@ -7,6 +7,7 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.inList
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.select
 import tech.figure.objectstore.gateway.model.ObjectPermissionsTable.isObjectWithMeta
 import tech.figure.objectstore.gateway.model.ObjectPermissionsTable.storageKeyAddress
 import tech.figure.objectstore.gateway.sql.offsetDatetime
@@ -55,6 +56,22 @@ open class ObjectPermissionClass : UUIDEntityClass<ObjectPermission>(ObjectPermi
         ObjectPermissionsTable.objectHash eq objectHash and
             (ObjectPermissionsTable.granteeAddress eq granteeAddress)
     }.firstOrNull()
+
+    fun findByObjectHashAndGranterAddress(objectHash: String, granterAddress: String): List<ObjectPermission> = findByObjectHashesAndGranterAddress(
+        objectHashes = listOf(objectHash),
+        granterAddress = granterAddress,
+    )[objectHash] ?: emptyList()
+
+    fun findByObjectHashesAndGranterAddress(objectHashes: Collection<String>, granterAddress: String): Map<String, List<ObjectPermission>> = find {
+        ObjectPermissionsTable.objectHash inList objectHashes and
+            (ObjectPermissionsTable.granterAddress eq granterAddress)
+    }.groupBy { it.objectHash }
+
+    fun findHashesByGranterAddress(granterAddress: String): Set<String> = ObjectPermissionsTable
+        .slice(ObjectPermissionsTable.objectHash)
+        .select { ObjectPermissionsTable.granterAddress eq granterAddress }
+        .map { it[ObjectPermissionsTable.objectHash] }
+        .toSet()
 
     fun deleteByObjectHashGranterAndGranteeAddresses(objectHash: String, granterAddress: String, granteeAddresses: List<String>) = ObjectPermissionsTable.deleteWhere {
         ObjectPermissionsTable.objectHash eq objectHash and

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/repository/ObjectPermissionsRepository.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/repository/ObjectPermissionsRepository.kt
@@ -26,7 +26,19 @@ class ObjectPermissionsRepository {
         ObjectPermission.findByObjectHashAndGranteeAddress(objectHash, granteeAddress)
     }
 
+    fun getAccessPermissionsForGranter(objectHash: String, granterAddress: String): List<ObjectPermission> = transaction {
+        ObjectPermission.findByObjectHashAndGranterAddress(objectHash = objectHash, granterAddress = granterAddress)
+    }
+
     fun revokeAccessPermissions(objectHash: String, granterAddress: String, granteeAddresses: List<String>) = transaction {
         ObjectPermission.deleteByObjectHashGranterAndGranteeAddresses(objectHash, granterAddress, granteeAddresses)
+    }
+
+    fun getAccessPermissionsForGranterByHashes(objectHashes: Collection<String>, granterAddress: String): Map<String, List<ObjectPermission>> = transaction {
+        ObjectPermission.findByObjectHashesAndGranterAddress(objectHashes = objectHashes, granterAddress = granterAddress)
+    }
+
+    fun getAllGranterHashes(granterAddress: String): Set<String> = transaction {
+        ObjectPermission.findHashesByGranterAddress(granterAddress = granterAddress)
     }
 }

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServer.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServer.kt
@@ -11,8 +11,8 @@ import org.lognet.springboot.grpc.GRpcService
 import org.springframework.beans.factory.annotation.Qualifier
 import tech.figure.objectstore.gateway.GatewayGrpc
 import tech.figure.objectstore.gateway.GatewayOuterClass
-import tech.figure.objectstore.gateway.GatewayOuterClass.BatchGrantObjectPermissionRequest
-import tech.figure.objectstore.gateway.GatewayOuterClass.BatchGrantObjectPermissionRequest.GrantTargetCase
+import tech.figure.objectstore.gateway.GatewayOuterClass.BatchGrantObjectPermissionsRequest
+import tech.figure.objectstore.gateway.GatewayOuterClass.BatchGrantObjectPermissionsRequest.GrantTargetCase
 import tech.figure.objectstore.gateway.GatewayOuterClass.BatchGrantScopePermissionRequest
 import tech.figure.objectstore.gateway.GatewayOuterClass.BatchGrantScopePermissionResponse
 import tech.figure.objectstore.gateway.GatewayOuterClass.GrantObjectPermissionsRequest
@@ -108,14 +108,15 @@ class ObjectStoreGatewayServer(
         objectService.grantAccess(request.hash, request.granteeAddress, address()).let {
             responseObserver.onNext(
                 GrantObjectPermissionsResponse.newBuilder()
-                    .setRequest(request)
+                    .setHash(request.hash)
+                    .setGranteeAddress(request.granteeAddress)
                     .build()
             )
         }
     }
 
     override fun batchGrantObjectPermissions(
-        request: BatchGrantObjectPermissionRequest,
+        request: BatchGrantObjectPermissionsRequest,
         responseObserver: StreamObserver<GrantObjectPermissionsResponse>,
     ) {
         val (granteeAddress, targetHashes) = when (request.grantTargetCase) {
@@ -130,8 +131,8 @@ class ObjectStoreGatewayServer(
             emitResponse = { hash, grantee ->
                 responseObserver.onNext(
                     GrantObjectPermissionsResponse.newBuilder().also { response ->
-                        response.requestBuilder.hash = hash
-                        response.requestBuilder.granteeAddress = grantee
+                        response.hash = hash
+                        response.granteeAddress = grantee
                     }.build()
                 )
             },

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/service/ObjectService.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/service/ObjectService.kt
@@ -20,8 +20,8 @@ import tech.figure.objectstore.gateway.configuration.BatchProperties
 import tech.figure.objectstore.gateway.configuration.BeanQualifiers
 import tech.figure.objectstore.gateway.configuration.ProvenanceProperties
 import tech.figure.objectstore.gateway.exception.AccessDeniedException
-import tech.figure.objectstore.gateway.exception.ExistingGrantException
 import tech.figure.objectstore.gateway.exception.InvalidInputException
+import tech.figure.objectstore.gateway.exception.ResourceAlreadyExistsException
 import tech.figure.objectstore.gateway.repository.DataStorageAccountsRepository
 import tech.figure.objectstore.gateway.repository.ObjectPermissionsRepository
 import tech.figure.objectstore.gateway.service.Bech32Verification.Failure
@@ -162,7 +162,7 @@ class ObjectService(
             throw AccessDeniedException("Granter [$granterAddress] has no authority to grant on hash [$hash]")
         }
         if (existingObjects.any { it.granteeAddress == granteeAddress }) {
-            throw ExistingGrantException("Grantee [$granteeAddress] has already been granted permissions to hash [$hash]")
+            throw ResourceAlreadyExistsException("Grantee [$granteeAddress] has already been granted permissions to hash [$hash]")
         }
         val existingObject = existingObjects.first()
         objectPermissionsRepository.addAccessPermission(

--- a/server/src/main/resources/application-container.properties
+++ b/server/src/main/resources/application-container.properties
@@ -1,3 +1,7 @@
+# Batch Process Configuration
+batch.max_provided_records=${BATCH_MAX_PROVIDED_RECORDS:500}
+batch.thread_count=${BATCH_THREAD_COUNT:20}
+
 # Event Stream Configuration
 event.stream.websocket_uri=${EVENT_STREAM_WEBSOCKET_URI}
 event.stream.epoch_height=${EVENT_STREAM_EPOCH_HEIGHT}

--- a/server/src/main/resources/application-development.properties
+++ b/server/src/main/resources/application-development.properties
@@ -1,3 +1,7 @@
+# Batch Process Configuration
+batch.max_provided_records=500
+batch.thread_count=20
+
 # Event Stream Configuration
 event.stream.websocket_uri=ws://localhost:26657
 event.stream.epoch_height=1

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/service/ObjectServiceTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/service/ObjectServiceTest.kt
@@ -47,6 +47,7 @@ import kotlin.test.fail
 @OptIn(ExperimentalCoroutinesApi::class)
 class ObjectServiceTest {
     lateinit var accountsRepository: DataStorageAccountsRepository
+    lateinit var addressVerificationService: AddressVerificationService
     lateinit var batchProperties: BatchProperties
     lateinit var batchScope: CoroutineScope
     lateinit var osClient: CachedOsClient
@@ -69,6 +70,7 @@ class ObjectServiceTest {
     @BeforeEach
     fun setUp() {
         accountsRepository = mockk()
+        addressVerificationService = mockk()
         batchScope = TestCoroutineScope()
         osClient = mockk()
         objectPermissionsRepository = mockk()
@@ -78,6 +80,7 @@ class ObjectServiceTest {
 
         objectService = ObjectService(
             accountsRepository = accountsRepository,
+            addressVerificationService = addressVerificationService,
             batchProperties = batchProperties,
             objectStoreClient = osClient,
             encryptionKeys = registeredEncryptionKeys,

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/service/ObjectServiceTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/service/ObjectServiceTest.kt
@@ -19,10 +19,14 @@ import io.provenance.scope.objectstore.util.base64Decode
 import io.provenance.scope.util.sha256
 import io.provenance.scope.util.sha256String
 import io.provenance.scope.util.toByteString
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScope
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.ArgumentMatchers.any
+import tech.figure.objectstore.gateway.configuration.BatchProperties
 import tech.figure.objectstore.gateway.configuration.ProvenanceProperties
 import tech.figure.objectstore.gateway.exception.AccessDeniedException
 import tech.figure.objectstore.gateway.helpers.mockDime
@@ -40,8 +44,11 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ObjectServiceTest {
     lateinit var accountsRepository: DataStorageAccountsRepository
+    lateinit var batchProperties: BatchProperties
+    lateinit var batchScope: CoroutineScope
     lateinit var osClient: CachedOsClient
     lateinit var objectPermissionsRepository: ObjectPermissionsRepository
     lateinit var provenanceProperties: ProvenanceProperties
@@ -62,18 +69,22 @@ class ObjectServiceTest {
     @BeforeEach
     fun setUp() {
         accountsRepository = mockk()
+        batchScope = TestCoroutineScope()
         osClient = mockk()
         objectPermissionsRepository = mockk()
 
+        batchProperties = BatchProperties(maxProvidedRecords = 10, threadCount = 10)
         provenanceProperties = ProvenanceProperties(false, "pio-fakenet-1", URI(""))
 
         objectService = ObjectService(
             accountsRepository = accountsRepository,
+            batchProperties = batchProperties,
             objectStoreClient = osClient,
             encryptionKeys = registeredEncryptionKeys,
             masterKey = masterKey,
             objectPermissionsRepository = objectPermissionsRepository,
             provenanceProperties = provenanceProperties,
+            batchProcessScope = batchScope,
         )
     }
 

--- a/server/src/test/resources/application.properties
+++ b/server/src/test/resources/application.properties
@@ -1,3 +1,7 @@
+# Batch Configuration
+batch.max_provided_records=500
+batch.thread_count=10
+
 # Event Stream Configuration
 event.stream.websocket_uri=ws://localhost:26657
 event.stream.rpc_uri=http://localhost:26657


### PR DESCRIPTION
# Description
This functionality was sorely missing from the application.  It allows existing granters to grant access to objects to new values, instead of only on object write.  It also adds a batch grant option that streams all added hashes as they are intercepted.

## Change Summary
- Expose client dependencies as API to ensure downstream consumers don't need to hunt down and import their own versions.
- Add object and batch object grant optionality to the application server and client.
- Compile and export kotlin protos to allow for flow exposure in the client.
- Allow batch rpc processes to be configurable.
- Create new queries to facilitate granter access grant discovery.
- Expand the Gateway server tests to do round-trip calls into the `ObjectService` versus mocking it, ensuring that this new stuff actually works end-to-end.