### PR TITLE
Bugfix: Object grant does not terminate the request

### DIFF
--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServer.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServer.kt
@@ -112,6 +112,7 @@ class ObjectStoreGatewayServer(
                     .setGranteeAddress(request.granteeAddress)
                     .build()
             )
+            responseObserver.onCompleted()
         }
     }
 

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServerTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServerTest.kt
@@ -271,6 +271,7 @@ class ObjectStoreGatewayServerTest {
                 message = "The permission should be granted and a record should be ported to the db",
             )
         }
+        verify { responseObserver.onCompleted() }
     }
 
     @Test
@@ -382,6 +383,7 @@ class ObjectStoreGatewayServerTest {
             val permission = repository.getAccessPermission(objectHash = interceptedHash, granteeAddress = grantee.bech32Address)
             assertNotNull(actual = permission, message = "Expected the grant to exist in the database")
         }
+        verify { responseObserver.onCompleted() }
     }
 
     @Test
@@ -416,6 +418,7 @@ class ObjectStoreGatewayServerTest {
                 assertNull(actual = permission, message = "Expected an untargeted grant hash to be omitted from grants")
             }
         }
+        verify { responseObserver.onCompleted() }
     }
 
     @Test


### PR DESCRIPTION
# Description
I forgot to terminate the rpc request in the gateway server for granting an object, so that route always times out :(