### PR TITLE
Bugfix: Async stream production isn't viable with standard sync server implementation

### DIFF
--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/AppProperties.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/AppProperties.kt
@@ -12,7 +12,6 @@ import java.util.UUID
 @Validated
 data class BatchProperties(
     val maxProvidedRecords: Int,
-    val threadCount: Int,
 )
 
 @ConstructorBinding

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/BeanQualifiers.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/BeanQualifiers.kt
@@ -1,7 +1,6 @@
 package tech.figure.objectstore.gateway.configuration
 
 object BeanQualifiers {
-    const val BATCH_PROCESS_COROUTINE_SCOPE_QUALIFIER = "batchProcessCoroutineScopeBean"
     const val EVENT_STREAM_COROUTINE_SCOPE_QUALIFIER = "eventStreamCoroutineScopeBean"
     const val OBJECTSTORE_ENCRYPTION_KEYS: String = "objectStoreEncryptionKeys"
     const val OBJECTSTORE_PRIVATE_KEYS: String = "objectStorePrivateKeys"

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/CoroutineConfig.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/CoroutineConfig.kt
@@ -7,12 +7,6 @@ import tech.figure.objectstore.gateway.util.CoroutineUtil
 
 @Configuration
 class CoroutineConfig {
-    @Bean(BeanQualifiers.BATCH_PROCESS_COROUTINE_SCOPE_QUALIFIER)
-    fun batchProcessScope(batchProperties: BatchProperties): CoroutineScope = CoroutineUtil.newSingletonScope(
-        scopeName = CoroutineScopeNames.BATCH_PROCESS_SCOPE,
-        threadCount = batchProperties.threadCount,
-    )
-
     @Bean(BeanQualifiers.EVENT_STREAM_COROUTINE_SCOPE_QUALIFIER)
     fun eventStreamScope(eventStreamProperties: EventStreamProperties): CoroutineScope = CoroutineUtil.newSingletonScope(
         scopeName = CoroutineScopeNames.EVENT_STREAM_SCOPE,

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServer.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayServer.kt
@@ -112,6 +112,7 @@ class ObjectStoreGatewayServer(
                     .setGranteeAddress(request.granteeAddress)
                     .build()
             )
+            responseObserver.onCompleted()
         }
     }
 

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayStreamServer.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/server/ObjectStoreGatewayStreamServer.kt
@@ -1,0 +1,28 @@
+package tech.figure.objectstore.gateway.server
+
+import kotlinx.coroutines.flow.Flow
+import org.lognet.springboot.grpc.GRpcService
+import tech.figure.objectstore.gateway.GatewayGrpcKt
+import tech.figure.objectstore.gateway.GatewayOuterClass.BatchGrantObjectPermissionsRequest
+import tech.figure.objectstore.gateway.GatewayOuterClass.BatchGrantObjectPermissionsRequest.GrantTargetCase
+import tech.figure.objectstore.gateway.GatewayOuterClass.GrantObjectPermissionsResponse
+import tech.figure.objectstore.gateway.address
+import tech.figure.objectstore.gateway.exception.InvalidInputException
+import tech.figure.objectstore.gateway.server.interceptor.JwtServerInterceptor
+import tech.figure.objectstore.gateway.service.ObjectService
+
+@GRpcService(interceptors = [JwtServerInterceptor::class])
+class ObjectStoreGatewayStreamServer(private val objectService: ObjectService) : GatewayGrpcKt.GatewayCoroutineImplBase() {
+    override fun batchGrantObjectPermissions(request: BatchGrantObjectPermissionsRequest): Flow<GrantObjectPermissionsResponse> {
+        val (granteeAddress, targetHashes) = when (request.grantTargetCase) {
+            GrantTargetCase.ALL_HASHES -> request.allHashes.granteeAddress to null
+            GrantTargetCase.SPECIFIED_HASHES -> request.specifiedHashes.let { it.granteeAddress to it.targetHashesList }
+            else -> throw InvalidInputException("A grant target must be supplied")
+        }
+        return objectService.batchGrantAccess(
+            granteeAddress = granteeAddress,
+            granterAddress = address(),
+            targetHashes = targetHashes,
+        )
+    }
+}

--- a/server/src/main/resources/application-container.properties
+++ b/server/src/main/resources/application-container.properties
@@ -1,6 +1,5 @@
 # Batch Process Configuration
 batch.max_provided_records=${BATCH_MAX_PROVIDED_RECORDS:500}
-batch.thread_count=${BATCH_THREAD_COUNT:20}
 
 # Event Stream Configuration
 event.stream.websocket_uri=${EVENT_STREAM_WEBSOCKET_URI}

--- a/server/src/main/resources/application-development.properties
+++ b/server/src/main/resources/application-development.properties
@@ -1,6 +1,5 @@
 # Batch Process Configuration
 batch.max_provided_records=500
-batch.thread_count=20
 
 # Event Stream Configuration
 event.stream.websocket_uri=ws://localhost:26657

--- a/server/src/test/kotlin/tech/figure/objectstore/gateway/service/ObjectServiceTest.kt
+++ b/server/src/test/kotlin/tech/figure/objectstore/gateway/service/ObjectServiceTest.kt
@@ -19,9 +19,7 @@ import io.provenance.scope.objectstore.util.base64Decode
 import io.provenance.scope.util.sha256
 import io.provenance.scope.util.sha256String
 import io.provenance.scope.util.toByteString
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -49,7 +47,6 @@ class ObjectServiceTest {
     lateinit var accountsRepository: DataStorageAccountsRepository
     lateinit var addressVerificationService: AddressVerificationService
     lateinit var batchProperties: BatchProperties
-    lateinit var batchScope: CoroutineScope
     lateinit var osClient: CachedOsClient
     lateinit var objectPermissionsRepository: ObjectPermissionsRepository
     lateinit var provenanceProperties: ProvenanceProperties
@@ -71,11 +68,10 @@ class ObjectServiceTest {
     fun setUp() {
         accountsRepository = mockk()
         addressVerificationService = mockk()
-        batchScope = TestCoroutineScope()
         osClient = mockk()
         objectPermissionsRepository = mockk()
 
-        batchProperties = BatchProperties(maxProvidedRecords = 10, threadCount = 10)
+        batchProperties = BatchProperties(maxProvidedRecords = 10)
         provenanceProperties = ProvenanceProperties(false, "pio-fakenet-1", URI(""))
 
         objectService = ObjectService(
@@ -87,7 +83,6 @@ class ObjectServiceTest {
             masterKey = masterKey,
             objectPermissionsRepository = objectPermissionsRepository,
             provenanceProperties = provenanceProperties,
-            batchProcessScope = batchScope,
         )
     }
 

--- a/server/src/test/resources/application.properties
+++ b/server/src/test/resources/application.properties
@@ -1,6 +1,5 @@
 # Batch Configuration
 batch.max_provided_records=500
-batch.thread_count=10
 
 # Event Stream Configuration
 event.stream.websocket_uri=ws://localhost:26657


### PR DESCRIPTION
# Description
The existing implementation in the release candidate was using the standard rpc java implementation, which doesn't work with async emits in a streaming context.  To facilitate this process, I created a supplemental streaming server that implements the coroutine functionality provided in grpckt.

## Change Summary
- Remove batch processing scope now that the process just returns a `Flow`, which removed the need for configurable thread counts, as the consumer handles how it's processed.
- Add new `ObjectStoreGatewayStreamServer` that handles async actions.  All processes could be swapped over to be here, but it would be a pain for downstream consumers to use because then they'd need to involve coroutine processes in their libs, and they're undoubtedly not doing that right now.
- Mod the tests to prove it all still works.

## Note
I was encountering an error: `INTERNAL: Connection closed after GOAWAY. HTTP/2 error code: INTERNAL_ERROR, debug data: Stream 1005 sent too many headers EOS: false` in my testing.  This is caused by using the `ResponseObserver` to call `onNext` in a multithreaded context, which is not allowed.  The flow stuff fixes this thing.