### PR TITLE
update grpc to make container happy

### DIFF
--- a/client/src/main/kotlin/tech/figure/objectstore/gateway/client/ClientConfig.kt
+++ b/client/src/main/kotlin/tech/figure/objectstore/gateway/client/ClientConfig.kt
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit
  * used in the GatewayClient after all other parameters are supplied as input.
  *
  * The remaining parameters are directly passed into a NettyChannelBuilder.  The documentation for the builder can be
- * found at: https://www.javadoc.io/doc/io.grpc/grpc-all/1.45.1/io/grpc/netty/NettyChannelBuilder.html
+ * found at: https://www.javadoc.io/doc/io.grpc/grpc-all/1.57.2/io/grpc/netty/NettyChannelBuilder.html
  */
 data class ClientConfig(
     val gatewayUri: URI,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,9 +4,9 @@ bouncycastle = "1.70"
 exposed = "0.37.3"
 figure-eventstream = "0.9.1"
 flyway = "8.0.2"
-grpc = "1.45.1" # If updating this value, ensure to update the doc reference in the ClientConfig class
+grpc = "1.57.2" # If updating this value, ensure to update the doc reference in the ClientConfig class
 grpc-kotlin = "1.3.0"
-grpc-springboot = "3.4.3"
+grpc-springboot = "5.1.4"
 hikari = "5.0.1"
 jackson = "2.12.5"
 jackson-protobuf = "0.9.13"
@@ -27,6 +27,7 @@ provenance-hdwallet = "0.1.15"
 provenance-proto = "1.13.0"
 provenance-scope = "0.4.9"
 scarlet = "0.1.12"
+springboot = "3.1.1"
 sqlite = "3.36.0.3"
 testcontainers = "1.17.3"
 
@@ -75,26 +76,26 @@ scarlet-message-adapter-moshi = { module = "com.tinder.scarlet:message-adapter-m
 scarlet = { module = "com.tinder.scarlet:scarlet", version.ref = "scarlet"}
 scarlet-stream-adapter-coroutines = { module = "com.tinder.scarlet:stream-adapter-coroutines", version.ref = "scarlet" }
 scarlet-websocket-okhttp = { module = "com.tinder.scarlet:websocket-okhttp", version.ref = "scarlet" }
-springboot-autoconfigure = { module = "org.springframework.boot:spring-boot-autoconfigure" }
-springboot-starter = { module = "org.springframework.boot:spring-boot-starter" }
-springboot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }
-springboot-starter-aop = { module = "org.springframework.boot:spring-boot-starter-aop" }
-springboot-starter-jetty = { module = "org.springframework.boot:spring-boot-starter-jetty" }
-springboot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web" }
+springboot-autoconfigure = { module = "org.springframework.boot:spring-boot-autoconfigure", version.ref = "springboot" }
+springboot-starter = { module = "org.springframework.boot:spring-boot-starter", version.ref = "springboot" }
+springboot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator", version.ref = "springboot" }
+springboot-starter-aop = { module = "org.springframework.boot:spring-boot-starter-aop", version.ref = "springboot" }
+springboot-starter-jetty = { module = "org.springframework.boot:spring-boot-starter-jetty", version.ref = "springboot" }
+springboot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web", version.ref = "springboot" }
 sqlite = { module = "org.xerial:sqlite-jdbc", version.ref = "sqlite" }
 
 # Test
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
-springboot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
+springboot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "springboot" }
 testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
 testcontainers-postgres = { module = "org.testcontainers:postgresql", version.ref = "testcontainers" }
 
 [bundles]
 database = ["exposed-core", "exposed-dao", "exposed-jdbc", "flyway", "hikari", "postgres", "sqlite"]
 eventstream = ["figure-eventstream-api", "figure-eventstream-api-model", "figure-eventstream-cli", "figure-eventstream-core"]
-grpc = ["grpc-netty", "grpc-netty-shaded", "grpc-protobuf", "grpc-stub", "grpc-springboot-starter", "grpc-kotlin-stub"]
+grpc = ["grpc-netty", "grpc-netty-shaded", "grpc-protobuf", "grpc-stub", "grpc-kotlin-stub"]
 jackson = ["jackson-module-kotlin", "jackson-module-protobuf"]
 kotlin = ["coroutines-core-jvm", "coroutines-reactor", "coroutines-jdk8", "coroutines-slf4j", "kotlin-allopen", "kotlin-reflect", "kotlin-stdlib-jdk8"]
 logging = ["kotlin-logging"]

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
         libs.java.jwt,
         libs.okhttp3,
         libs.provenance.blockapi.client,
+        libs.grpc.springboot.starter,
         libs.bundles.database,
         libs.bundles.eventstream,
         libs.bundles.grpc,

--- a/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/AppProperties.kt
+++ b/server/src/main/kotlin/tech/figure/objectstore/gateway/configuration/AppProperties.kt
@@ -2,22 +2,20 @@ package tech.figure.objectstore.gateway.configuration
 
 import org.intellij.lang.annotations.Pattern
 import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.boot.context.properties.ConstructorBinding
+import org.springframework.boot.context.properties.bind.ConstructorBinding
 import org.springframework.validation.annotation.Validated
 import java.net.URI
 import java.util.UUID
 
-@ConstructorBinding
 @ConfigurationProperties(prefix = "batch")
 @Validated
-data class BatchProperties(
+data class BatchProperties @ConstructorBinding constructor(
     val maxProvidedRecords: Int,
 )
 
-@ConstructorBinding
 @ConfigurationProperties(prefix = "blockstream")
 @Validated
-data class BlockStreamProperties(
+data class BlockStreamProperties @ConstructorBinding constructor(
     val type: String,
     val uri: URI,
     val apiKey: String? = null,
@@ -36,10 +34,9 @@ data class BlockStreamProperties(
         ?: throw IllegalArgumentException("Unsupported block stream type [$type]")
 }
 
-@ConstructorBinding
 @ConfigurationProperties(prefix = "objectstore")
 @Validated
-data class ObjectStoreProperties(
+data class ObjectStoreProperties @ConstructorBinding constructor(
     val uri: URI,
     val privateKeys: List<String>,
     val masterKey: String,
@@ -49,18 +46,16 @@ data class ObjectStoreProperties(
 )
 
 @Validated
-@ConstructorBinding
 @ConfigurationProperties(prefix = "provenance")
-data class ProvenanceProperties(
+data class ProvenanceProperties @ConstructorBinding constructor(
     val mainNet: Boolean,
     val chainId: String,
     val channelUri: URI,
 )
 
 @Validated
-@ConstructorBinding
 @ConfigurationProperties(prefix = "db")
-data class DatabaseProperties(
+data class DatabaseProperties @ConstructorBinding constructor(
     val type: String,
     val name: String,
     val username: String,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,10 +15,10 @@ pluginManagement {
     plugins {
         kotlin("jvm") version "1.9.0"
         kotlin("plugin.spring") version "1.9.0" apply false
-        id("org.springframework.boot") version "2.6.4" apply false
-        id("io.spring.dependency-management") version "1.0.11.RELEASE" apply false
+        id("org.springframework.boot") version "3.1.1" apply false
+        id("io.spring.dependency-management") version "1.1.3" apply false
         id("idea")
-        id("com.google.protobuf") version "0.8.18" apply false
+        id("com.google.protobuf") version "0.9.4" apply false
         id("maven-publish") apply false
         id("io.github.gradle-nexus.publish-plugin") version "1.1.0" apply false
         id("signing") apply false

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -12,5 +12,6 @@ dependencies {
 
     listOf(
         libs.bundles.test.kotlin,
+        libs.kotlin.logging,
     ).forEach(::testImplementation)
 }


### PR DESCRIPTION
Was getting the below error... We had this with service-group-manager a while back and the fix was to upgrade grpc to >= `1.56.1`... So here is that. I also realized that I hadn't updated springboot to v3 and the grpc-springboot-starter thing with it to a version that uses the appropriate new grpc version.

```bash
Root WebApplicationContext: initialization completed in 3347 ms
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x0000000000003fd6, pid=9, tid=10
#
# JRE version: OpenJDK Runtime Environment Zulu17.44+15-CA (17.0.8+7) (build 17.0.8+7-LTS)
# Java VM: OpenJDK 64-Bit Server VM Zulu17.44+15-CA (17.0.8+7-LTS, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# C  [libio_grpc_netty_shaded_netty_transport_native_epoll_x86_649124014460744275403.so+0xbc1a]  parsePackagePrefix+0xba
#
# Core dump will be written. Default location: /core.%e.9.%t
#
# An error report file with more information is saved as:
# //hs_err_pid9.log
#
# If you would like to submit a bug report, please visit:
#   http://www.azul.com/support/
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#
Aborted (core dumped)
```