### PR TITLE
Bugfix: Use the latest compatible version of sqlite

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ provenance-proto = "1.13.0"
 provenance-scope = "0.4.9"
 scarlet = "0.1.12"
 springboot = "3.1.1"
-sqlite = "3.36.0.3"
+sqlite = "3.42.0.1"
 testcontainers = "1.17.3"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ provenance-proto = "1.13.0"
 provenance-scope = "0.4.9"
 scarlet = "0.1.12"
 springboot = "3.1.1"
-sqlite = "3.42.0.1"
+sqlite = "3.42.0.0"
 testcontainers = "1.17.3"
 
 [libraries]


### PR DESCRIPTION
# Description
This later version of sqlite is compatible with arm64 native binaries.  The previous version would fail to find the necessary binary when running the arm64 version.